### PR TITLE
[gcp/iam] enhance the management SA roles

### DIFF
--- a/modules/gcp/iam/iam_management_sa.tf
+++ b/modules/gcp/iam/iam_management_sa.tf
@@ -5,6 +5,7 @@ resource "google_service_account" "management-sa" {
   
 }
 
+// Role 1: To be able to manage a cluster. https://cloud.google.com/iam/docs/understanding-roles#container.clusterAdmin
 resource "google_project_iam_member" "management-container-binding" {
   project = var.gcp_project_id
   role    = "roles/container.clusterAdmin"
@@ -17,6 +18,7 @@ resource "google_project_iam_member" "management-container-binding" {
   }
 }
 
+// Role 2: To be able to read the bucket. https://cloud.google.com/iam/docs/understanding-roles#storage.bucketViewer
 resource "google_project_iam_member" "management-storage-binding" {
   project = var.gcp_project_id
   role    = "roles/storage.bucketViewer"
@@ -29,6 +31,46 @@ resource "google_project_iam_member" "management-storage-binding" {
   }
 }
 
+// Role 3: To be able to set a service account on nodes. https://cloud.google.com/iam/docs/understanding-roles#container.admin
+resource "google_project_iam_member" "management-service-account-user-binding" {
+  project = var.gcp_project_id
+  role    = "roles/iam.serviceAccountUser"
+  member  = "serviceAccount:${google_service_account.management-sa.email}"
+  
+  condition {
+    title       = "zilliz_byoc_service_account_user"
+    description = "zilliz byoc service account user for gke node"
+    expression  = "resource.name.startsWith(\"projects/${var.gcp_project_id}/serviceAccounts/${google_service_account.gke-node-sa.unique_id}\")"
+  }
+}
+
+// Role 4: To be able to get the instance group manager. https://cloud.google.com/iam/docs/understanding-roles#iam.serviceAccountUser
+// Generate a random id to avoid role id collision. GCP custom roles have soft-delete behavior, whose name remains locked for 30 more days. During this period, creating a role with the same name may cause confusing behavior between undelete and update operations.
+resource "random_id" "short_uuid" {
+  byte_length = 3 
+}
+
+resource "google_project_iam_custom_role" "zilliz-byoc-gke-minimum-additional-role" {
+  role_id     = "zillizByocGkeMinimumAdditionalRole${random_id.short_uuid.hex}"
+  title       = "Zilliz BYOC GKE Minimum Additional Role"
+  description = "Custom role for Zilliz BYOC with minimum required permissions for GKE node management"
+  permissions = [
+    "compute.instanceGroupManagers.get"
+  ]
+  project = var.gcp_project_id
+}
+
+resource "google_project_iam_member" "management-gke-minimum-additional-role-binding" {
+  project = var.gcp_project_id
+  role    = google_project_iam_custom_role.zilliz-byoc-gke-minimum-additional-role.id
+  member  = "serviceAccount:${google_service_account.management-sa.email}"
+  
+  condition {
+    title       = "zilliz_byoc_gke_minimum"
+    description = "zilliz byoc gke minimum permissions"
+    expression  = join(" || ", [for zone in var.gcp_zones : "resource.name.startsWith(\"projects/${var.gcp_project_id}/zones/${zone}/instanceGroupManagers/gke-${var.gke_cluster_name}\")"])
+  }
+}
 
 # Allow zilliz service account to impersonate customer service account
 resource "google_service_account_iam_binding" "impersonate" {
@@ -39,5 +81,3 @@ resource "google_service_account_iam_binding" "impersonate" {
     "serviceAccount:${var.delegate_from}"
   ]
 }
-
-// TODO: impersonate

--- a/modules/gcp/iam/terraform.tfvars.json
+++ b/modules/gcp/iam/terraform.tfvars.json
@@ -1,9 +1,11 @@
 {
     "gcp_project_id": "zilliz-byoc-user-prj1",
     "gcp_region": "us-west1",
+    "gcp_zones": ["us-west1-a", "us-west1-b", "us-west1-c"],
     "gke_cluster_name": "zilliz-byoc-gke",
     "storage_bucket_name": "zilliz-byoc-bucket",
     "storage_service_account_name": "zilliz-byoc-bucket-sa",
     "management_service_account_name": "zilliz-byoc-management-sa",
-    "gke_node_service_account_name": "zilliz-byoc-gke-node-sa"
+    "gke_node_service_account_name": "zilliz-byoc-gke-node-sa",
+    "delegate_from": "zilliz-byoc-management-sa@vdc-dev-test.iam.gserviceaccount.com"
 }

--- a/modules/gcp/iam/variables.tf
+++ b/modules/gcp/iam/variables.tf
@@ -57,3 +57,10 @@ variable "delegate_from" {
   type = string
   description = "The service account that can impersonate the customer service account"
 }
+
+variable "gcp_zones" { 
+  description = "The GCP zones for the GKE cluster."
+  type        = list(string)
+  default     = ["us-west1-a", "us-west1-b", "us-west1-c"]
+  nullable    = false
+}


### PR DESCRIPTION
- Assign the `roles/iam.serviceAccountUser` role to the management service account to enable it to configure service accounts on nodes.
- Grant the `compute.instanceGroupManagers.get` permission to the management service account to allow it to inspect the GKE Cluster's instance groups.