### PR TITLE
chore: byoc op name has been renamed to byoc i

### DIFF
--- a/examples/aws-project-byoc-I/data.tf
+++ b/examples/aws-project-byoc-I/data.tf
@@ -3,24 +3,24 @@ resource "random_id" "short_uuid" {
 }
 locals {
   is_existing_vpc = var.customer_vpc_id != ""
-  short_project_id = substr(data.zillizcloud_byoc_op_project_settings.this.id, 0, 10)
+  short_project_id = substr(data.zillizcloud_byoc_i_project_settings.this.id, 0, 10)
   prefix_name = "zilliz-${local.short_project_id}-${random_id.short_uuid.hex}"
-  dataplane_id = data.zillizcloud_byoc_op_project_settings.this.data_plane_id
+  dataplane_id = data.zillizcloud_byoc_i_project_settings.this.data_plane_id
   vpc_id = local.is_existing_vpc ? var.customer_vpc_id :module.my_vpc[0].vpc_id
   security_group_id = local.is_existing_vpc ? var.customer_security_group_id : module.my_vpc[0].security_group_id
   subnet_ids =  local.is_existing_vpc ? var.customer_private_subnet_ids : module.my_vpc[0].private_subnets
   eks_control_plane_subnet_ids = local.is_existing_vpc ? var.customer_eks_control_plane_private_subnet_ids : module.my_vpc[0].private_subnets
-  aws_region = replace(data.zillizcloud_byoc_op_project_settings.this.region, "aws-", "")
-  enable_private_link = var.enable_private_link != null ? var.enable_private_link : data.zillizcloud_byoc_op_project_settings.this.private_link_enabled
+  aws_region = replace(data.zillizcloud_byoc_i_project_settings.this.region, "aws-", "")
+  enable_private_link = var.enable_private_link != null ? var.enable_private_link : data.zillizcloud_byoc_i_project_settings.this.private_link_enabled
   external_id = data.zillizcloud_external_id.current.id
   agent_config = {
-    auth_token = data.zillizcloud_byoc_op_project_settings.this.op_config.token
-    tag        = data.zillizcloud_byoc_op_project_settings.this.op_config.agent_image_url
+    auth_token = data.zillizcloud_byoc_i_project_settings.this.op_config.token
+    tag        = data.zillizcloud_byoc_i_project_settings.this.op_config.agent_image_url
   }
 
-  k8s_node_groups = data.zillizcloud_byoc_op_project_settings.this.node_quotas
-  project_id = data.zillizcloud_byoc_op_project_settings.this.project_id
-  data_plane_id = data.zillizcloud_byoc_op_project_settings.this.data_plane_id
+  k8s_node_groups = data.zillizcloud_byoc_i_project_settings.this.node_quotas
+  project_id = data.zillizcloud_byoc_i_project_settings.this.project_id
+  data_plane_id = data.zillizcloud_byoc_i_project_settings.this.data_plane_id
   s3_bucket_id = module.my_s3.s3_bucket_id
   eks_role = module.my_eks.eks_role
   maintenance_role = module.my_eks.maintenance_role

--- a/examples/aws-project-byoc-I/main.tf
+++ b/examples/aws-project-byoc-I/main.tf
@@ -1,4 +1,4 @@
-data "zillizcloud_byoc_op_project_settings" "this" {
+data "zillizcloud_byoc_i_project_settings" "this" {
   project_id    = var.project_id
   data_plane_id = var.dataplane_id
 }
@@ -63,7 +63,7 @@ module "my_eks" {
 
 
 
-resource "zillizcloud_byoc_op_project_agent" "this" {
+resource "zillizcloud_byoc_i_project_agent" "this" {
   project_id    = local.project_id
   data_plane_id = local.data_plane_id
 
@@ -73,13 +73,13 @@ resource "zillizcloud_byoc_op_project_agent" "this" {
 
 
 
-resource "zillizcloud_byoc_op_project" "this" {
+resource "zillizcloud_byoc_i_project" "this" {
 
   project_id    = local.project_id
   data_plane_id = local.data_plane_id
 
   aws = {
-    region = data.zillizcloud_byoc_op_project_settings.this.region
+    region = data.zillizcloud_byoc_i_project_settings.this.region
 
     network = {
       vpc_id             = local.vpc_id
@@ -98,7 +98,7 @@ resource "zillizcloud_byoc_op_project" "this" {
   }
 
   // depend on private link to establish agent tunnel connection
-  depends_on = [zillizcloud_byoc_op_project_agent.this,
+  depends_on = [zillizcloud_byoc_i_project_agent.this,
     module.my_eks, module.my_private_link, module.my_vpc]
   lifecycle {
      ignore_changes = [data_plane_id, project_id, aws, ext_config]

--- a/examples/aws-project-byoc-I/provider.tf
+++ b/examples/aws-project-byoc-I/provider.tf
@@ -8,7 +8,7 @@ terraform {
     }
     zillizcloud = {
       source  = "zilliztech/zillizcloud"
-      version = "~> 0.4.10"
+      version = "~> 0.5.0"
     }
   }
 }


### PR DESCRIPTION
This pull request updates the Terraform configuration for the BYOC (Bring Your Own Cloud) AWS project to use the new `zillizcloud_byoc_i` resources and data sources, replacing the deprecated `zillizcloud_byoc_op` equivalents. Additionally, it updates the `zillizcloud` provider version. Below are the key changes:

### Migration to `zillizcloud_byoc_i` Resources and Data Sources:

* Updated `data "zillizcloud_byoc_op_project_settings"` to `data "zillizcloud_byoc_i_project_settings"` in `main.tf` and adjusted all references accordingly. [[1]](diffhunk://#diff-ceb04624b4562bef3d574bc1c348a358186f146c92d9ddbe00f611067d6ad03bL1-R1) [[2]](diffhunk://#diff-00c1d90efd83580bc7c354e3e6dba22fb96864285cb3346a6442c149f26c429cL6-R23)
* Replaced `resource "zillizcloud_byoc_op_project_agent"` with `resource "zillizcloud_byoc_i_project_agent"` in `main.tf`.
* Replaced `resource "zillizcloud_byoc_op_project"` with `resource "zillizcloud_byoc_i_project"` in `main.tf`, including updates to dependencies and attributes. [[1]](diffhunk://#diff-ceb04624b4562bef3d574bc1c348a358186f146c92d9ddbe00f611067d6ad03bL76-R82) [[2]](diffhunk://#diff-ceb04624b4562bef3d574bc1c348a358186f146c92d9ddbe00f611067d6ad03bL101-R101)

### Provider Version Update:

* Updated the `zillizcloud` provider version from `~> 0.4.10` to `~> 0.5.0` in `provider.tf`.