### PR TITLE
Additional role for management sa

### DIFF
--- a/modules/gcp/iam/iam_gke_node_sa.tf
+++ b/modules/gcp/iam/iam_gke_node_sa.tf
@@ -2,14 +2,14 @@ resource "google_service_account" "gke-node-sa" {
   account_id   = var.gke_node_service_account_name
   display_name = "Zilliz gke node service account"
   project      = var.gcp_project_id
-  
+
 }
 
 resource "google_project_iam_member" "gke-node-binding" {
   project = var.gcp_project_id
   role    = "roles/container.defaultNodeServiceAccount"
   member  = "serviceAccount:${google_service_account.gke-node-sa.email}"
-  
+
   condition {
     title       = "zilliz_byoc_gke_node_service_account"
     description = "zilliz byoc gke node service account for container"

--- a/modules/gcp/iam/iam_management_sa.tf
+++ b/modules/gcp/iam/iam_management_sa.tf
@@ -2,7 +2,7 @@ resource "google_service_account" "management-sa" {
   account_id   = var.management_service_account_name
   display_name = "Zilliz management service account"
   project      = var.gcp_project_id
-  
+
 }
 
 // Role 1: To be able to manage a cluster. https://cloud.google.com/iam/docs/understanding-roles#container.clusterAdmin
@@ -17,7 +17,7 @@ resource "google_project_iam_member" "management-storage-binding" {
   project = var.gcp_project_id
   role    = "roles/storage.bucketViewer"
   member  = "serviceAccount:${google_service_account.management-sa.email}"
-  
+
   condition {
     title       = "zilliz_byoc_gcs_bucket_viewer"
     description = "zilliz byoc gcs bucket viewer for gcs bucket"
@@ -28,7 +28,7 @@ resource "google_project_iam_member" "management-storage-binding" {
 // Role 3: To be able to get the instance group manager. https://cloud.google.com/iam/docs/understanding-roles#iam.serviceAccountUser
 // Generate a random id to avoid role id collision. GCP custom roles have soft-delete behavior, whose name remains locked for 30 more days. During this period, creating a role with the same name may cause confusing behavior between undelete and update operations.
 resource "random_id" "short_uuid" {
-  byte_length = 3 
+  byte_length = 3
 }
 
 resource "google_project_iam_custom_role" "zilliz-byoc-gke-minimum-additional-role" {
@@ -45,7 +45,7 @@ resource "google_project_iam_member" "management-gke-minimum-additional-role-bin
   project = var.gcp_project_id
   role    = google_project_iam_custom_role.zilliz-byoc-gke-minimum-additional-role.id
   member  = "serviceAccount:${google_service_account.management-sa.email}"
-  
+
   condition {
     title       = "zilliz_byoc_gke_minimum"
     description = "zilliz byoc gke minimum permissions"
@@ -70,23 +70,24 @@ resource "google_service_account_iam_binding" "impersonate" {
   ]
 }
 
+// custom role to set iam policy on service account
 resource "google_project_iam_custom_role" "service_account_policy_setter" {
-  role_id     = "serviceAccountPolicySetter"
-  title       = "Service Account Policy Setter"
+  role_id = "serviceAccountPolicySetter"
+  title   = "Service Account Policy Setter"
   permissions = [
     "iam.serviceAccounts.getIamPolicy",
     "iam.serviceAccounts.setIamPolicy"
   ]
-  project     = var.gcp_project_id
-  stage       = "GA"
+  project = var.gcp_project_id
+  stage   = "GA"
 }
 
+// allow management service account to set roles/iam.workloadIdentityUser  on storage service account
 resource "google_service_account_iam_member" "service_account_policy_setter_binding" {
   service_account_id = google_service_account.storage-sa.name
-  # project = var.gcp_project_id
-  role    = google_project_iam_custom_role.service_account_policy_setter.id
+  role               = google_project_iam_custom_role.service_account_policy_setter.id
   member             = "serviceAccount:${google_service_account.management-sa.email}"
-  
+
   condition {
     title       = "LimitedRoleGranting"
     description = "Can only grant workload identity user role"

--- a/modules/gcp/iam/iam_storage_sa.tf
+++ b/modules/gcp/iam/iam_storage_sa.tf
@@ -28,16 +28,3 @@ resource "google_project_iam_member" "storage-bucket-viewer-binding" {
     expression  = "resource.name.startsWith(\"projects/_/buckets/${var.storage_bucket_name}\")"
   }
 }
-
-resource "google_iam_workload_identity_pool" "gke_pool" {
-  workload_identity_pool_id = "${var.gcp_project_id}-${random_id.short_uuid.hex}"
-  display_name              = "GKE Workload Identity Pool"
-  description              = "Identity pool for GKE workload identity"
-  project                  = var.gcp_project_id
-}
-
-resource "google_service_account_iam_member" "cluster-workload-identity" {
-  service_account_id = google_service_account.storage-sa.name
-  role    = "roles/iam.workloadIdentityUser"
-  member  = "principalSet://iam.googleapis.com/projects/${data.google_project.project.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.gke_pool.workload_identity_pool_id}/kubernetes.cluster/https://container.googleapis.com/v1/projects/${var.gcp_project_id}/locations/${var.gcp_region}/clusters/${var.gke_cluster_name}"
-}

--- a/modules/gcp/iam/iam_storage_sa.tf
+++ b/modules/gcp/iam/iam_storage_sa.tf
@@ -2,14 +2,14 @@ resource "google_service_account" "storage-sa" {
   account_id   = var.storage_service_account_name
   display_name = "Zilliz storage service account"
   project      = var.gcp_project_id
-  
+
 }
 
 resource "google_project_iam_member" "storage-object-admin-binding" {
   project = var.gcp_project_id
   role    = "roles/storage.objectAdmin"
   member  = "serviceAccount:${google_service_account.storage-sa.email}"
-  
+
   condition {
     title       = "zilliz_byoc_gcs_object_admin"
     description = "zilliz byoc gcs object admin for gcs bucket"
@@ -21,7 +21,7 @@ resource "google_project_iam_member" "storage-bucket-viewer-binding" {
   project = var.gcp_project_id
   role    = "roles/storage.bucketViewer"
   member  = "serviceAccount:${google_service_account.storage-sa.email}"
-  
+
   condition {
     title       = "zilliz_byoc_gcs_bucket_viewer"
     description = "zilliz byoc gcs bucket viewer for gcs bucket"

--- a/modules/gcp/iam/variables.tf
+++ b/modules/gcp/iam/variables.tf
@@ -6,8 +6,8 @@ variable "gcp_project_id" {
 
 variable "gcp_region" {
   description = "The GCP region of the Google Cloud Platform project."
-  type    = string
-  default = "us-west1"
+  type        = string
+  default     = "us-west1"
   nullable    = false
 }
 
@@ -26,7 +26,7 @@ variable "storage_bucket_name" {
     condition     = var.storage_bucket_name != ""
     error_message = "variable storage_bucket_name cannot be empty."
   }
-  
+
 }
 
 variable "gke_cluster_name" {
@@ -38,7 +38,7 @@ variable "gke_cluster_name" {
     condition     = var.gke_cluster_name != ""
     error_message = "variable gke_cluster_name cannot be empty."
   }
-  
+
 }
 
 variable "management_service_account_name" {
@@ -54,12 +54,12 @@ variable "gke_node_service_account_name" {
 }
 
 variable "delegate_from" {
-  type = string
+  type        = string
   description = "The service account that can impersonate the customer service account"
-    nullable    = false
+  nullable    = false
 }
 
-variable "gcp_zones" { 
+variable "gcp_zones" {
   description = "The GCP zones for the GKE cluster."
   type        = list(string)
   default     = ["us-west1-a", "us-west1-b", "us-west1-c"]

--- a/modules/gcp/iam/version.tf
+++ b/modules/gcp/iam/version.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source  = "hashicorp/google"
       version = "6.32.0"
     }
   }
@@ -12,8 +12,8 @@ terraform {
 
 # https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference
 provider "google" {
-  project                                       = var.gcp_project_id
-  region                                        = var.gcp_region
+  project = var.gcp_project_id
+  region  = var.gcp_region
 
   default_labels = {
     terraform = "true"


### PR DESCRIPTION
This pull request introduces changes to IAM configurations in GCP, focusing on adding a custom role for managing IAM policies and removing resources related to workload identity pools. The key updates enhance role-based access control and simplify the configuration by removing unused resources.

### Additions:

* **Custom Role for IAM Policy Management**:
  - Added a new `google_project_iam_custom_role` resource named `service_account_policy_setter` with permissions to get and set IAM policies on service accounts. This role is scoped to the specified GCP project.
  - Added a `google_service_account_iam_member` resource to bind the `service_account_policy_setter` role to the management service account, with a condition limiting its ability to grant only the `roles/iam.workloadIdentityUser` role.

### Removals:

* **Workload Identity Pool Resources**:
  - Removed the `google_iam_workload_identity_pool` resource used for GKE workload identity, along with its associated `google_service_account_iam_member` binding. These resources are no longer needed.