### PR TITLE
Remove booter tag variable and update ECR image selection

### DIFF
--- a/examples/aws-project-byoc-I/variables.tf
+++ b/examples/aws-project-byoc-I/variables.tf
@@ -127,19 +127,17 @@ variable "enable_manual_private_link" {
 }
 
 variable "booter" {
-  description = "Booter configuration including account ID, region, prefix, image, and tag"
+  description = "Booter configuration including account ID, region, prefix, image"
   type = object({
     account_id = optional(string, "")
     region     = optional(string, "")
     prefix     = optional(string, "")
     image      = optional(string, "")
-    tag        = optional(string, "")
   })
   default = {
     account_id = ""
     region     = ""
     prefix     = ""
     image      = ""
-    tag        = ""
   }
 }

--- a/modules/aws_byoc_i/eks/variables.tf
+++ b/modules/aws_byoc_i/eks/variables.tf
@@ -200,19 +200,17 @@ variable "customer_ecr" {
 }
 
 variable "booter" {
-  description = "Booter configuration including account ID, region, prefix, image, and tag"
+  description = "Booter configuration including account ID, region, prefix, image"
   type = object({
     account_id = optional(string, "")
     region     = optional(string, "")
     prefix     = optional(string, "")
     image      = optional(string, "")
-    tag        = optional(string, "")
   })
   default = {
     account_id = ""
     region     = ""
     prefix     = ""
     image      = ""
-    tag        = ""
   }
 }


### PR DESCRIPTION
Eliminated the 'tag' field from the booter variable in both example and module variable definitions. Refactored ECR image selection logic in locals.tf to remove explicit tag handling, improve fallback behavior, and streamline image pulling commands.