### PR TITLE
fix(security group): allow to ignore ingress rule

### DIFF
--- a/modules/aws_byoc_i/vpc/securitygroup.tf
+++ b/modules/aws_byoc_i/vpc/securitygroup.tf
@@ -57,4 +57,10 @@ resource "aws_security_group" "zilliz_byoc_security_group" {
     Name = "${local.prefix_name}-sg"
     Vendor = "zilliz-byoc"
   }, var.custom_tags)
+
+  lifecycle {
+    ignore_changes = [
+      ingress,
+    ]
+  }
 }


### PR DESCRIPTION
allow to ingnore ingress rule
because lb controller would change it later on, that would cause sg state drifted