### PR TITLE
Add block device mappings to EKS nodegroups

### DIFF
--- a/modules/aws_byoc_i/eks/eks_nodegroup.tf
+++ b/modules/aws_byoc_i/eks/eks_nodegroup.tf
@@ -55,6 +55,19 @@ resource "aws_launch_template" "core" {
     enabled = true
   }
 
+  block_device_mappings {
+    device_name = "/dev/xvda"
+
+    ebs {
+      delete_on_termination = "true"
+      encrypted             = "false"
+      iops                  = 3000
+      throughput            = 125
+      volume_size           = local.k8s_node_groups.core.disk_size
+      volume_type           = "gp3"
+    }
+  }
+
   tag_specifications {
     resource_type = "instance"
     tags = merge({
@@ -160,6 +173,19 @@ resource "aws_launch_template" "default" {
     enabled = true
   }
 
+  block_device_mappings {
+    device_name = "/dev/xvda"
+
+    ebs {
+      delete_on_termination = "true"
+      encrypted             = "false"
+      iops                  = 3000
+      throughput            = 125
+      volume_size           = local.k8s_node_groups.index.disk_size
+      volume_type           = "gp3"
+    }
+  }
+
   tag_specifications {
     resource_type = "instance"
     tags = merge({
@@ -208,7 +234,7 @@ resource "aws_launch_template" "diskann" {
       encrypted             = "false"
       iops                  = 3000
       throughput            = 125
-      volume_size           = 100
+      volume_size           = local.k8s_node_groups.search.disk_size
       volume_type           = "gp3"
     }
   }


### PR DESCRIPTION
Introduces explicit block device mappings for 'core' and 'default' launch templates, specifying EBS volume properties. Also updates 'diskann' launch template to use a variable for disk size instead of a hardcoded value, improving configurability.