### PR TITLE
Enable private DNS and remove Route53 resources

### DIFF
--- a/modules/aws_vpc/private_link.tf
+++ b/modules/aws_vpc/private_link.tf
@@ -13,41 +13,11 @@ resource "aws_vpc_endpoint" "byoc_endpoint" {
   vpc_endpoint_type   = "Interface"
   subnet_ids          = module.vpc.private_subnets
   security_group_ids  = [aws_security_group.zilliz_byoc_sg.id]
-  # private_dns_enabled = true
+  private_dns_enabled = true
 
   tags = {
     Name   = "zilliz-byoc-${var.name}-endpoint"
     Vendor = "zilliz-byoc"
     Caller = data.aws_caller_identity.current.arn
-  }
-}
-
-
-resource "aws_route53_zone" "byoc_private_zone" {
-  count = var.enable_private_link ? 1 : 0
-  name = local.config.private_zone_name
-  vpc {
-    vpc_id = module.vpc.vpc_id
-  }
-  comment = "Private hosted zone for BYOC project"
-
-  tags = {
-    Vendor = "zilliz-byoc"
-    Caller = data.aws_caller_identity.current.arn
-  }
-}
-
-resource "aws_route53_record" "byoc_endpoint_alias" {
-  count = var.enable_private_link ? 1 : 0
-  zone_id = aws_route53_zone.byoc_private_zone[0].zone_id
-  # if us-west-2, the name is zilliz-byoc-us
-  # if eu-central-1, the name is zilliz-byoc-eu
-  name    = "zilliz-byoc-${substr(var.region, 0, 2)}"
-  type    = "A"
-
-  alias {
-    name                   = aws_vpc_endpoint.byoc_endpoint[0].dns_entry[0].dns_name
-    zone_id               = aws_vpc_endpoint.byoc_endpoint[0].dns_entry[0].hosted_zone_id
-    evaluate_target_health = true
   }
 }


### PR DESCRIPTION
Set `private_dns_enabled` to true for the VPC endpoint and removed custom Route53 private zone and alias record resources. This simplifies DNS management by relying on AWS's built-in private DNS for interface endpoints.