### PR TITLE
fix: update object_ownership to BucketOwnerEnforced

### DIFF
--- a/modules/aws_byoc_i/s3/s3.tf
+++ b/modules/aws_byoc_i/s3/s3.tf
@@ -9,7 +9,7 @@ module "s3_bucket" {
   acl      = "private"
 
   control_object_ownership = true
-  object_ownership         = "ObjectWriter"
+  object_ownership         = "BucketOwnerEnforced"
 
   tags = merge({
     Vendor = "zilliz-byoc"


### PR DESCRIPTION
This pull request updates the S3 bucket configuration to enhance security by enforcing stricter ownership controls.

S3 bucket ownership configuration:

* Changed the `object_ownership` property in the `s3_bucket` module from `"ObjectWriter"` to `"BucketOwnerEnforced"` in `modules/aws_byoc_i/s3/s3.tf`, ensuring that the bucket owner has full control over all objects and preventing other AWS accounts from taking ownership of uploaded objects.