### PR TITLE
fix: remove Bucket ACL

### DIFF
--- a/modules/aws_byoc_i/s3/s3.tf
+++ b/modules/aws_byoc_i/s3/s3.tf
@@ -6,7 +6,6 @@ module "s3_bucket" {
   version = "3.15.1"
 
   bucket   = "${local.bucket_name}"
-  acl      = "private"
 
   control_object_ownership = true
   object_ownership         = "BucketOwnerEnforced"


### PR DESCRIPTION
A Bucket ACL is a legacy, should not be used when ObjectOwnership is enabled