### PR TITLE
fix: validation

### DIFF
--- a/examples/aws-project-byoc-I/validations.tf
+++ b/examples/aws-project-byoc-I/validations.tf
@@ -1,0 +1,55 @@
+# Validation checks using null_resource for older Terraform compatibility
+
+resource "null_resource" "validate_security_groups" {
+  # Trigger validation when any of the relevant variables change
+  triggers = {
+    customer_vpc_id                                    = var.customer_vpc_id
+    customer_cluster_additional_security_group_ids     = join(",", var.customer_cluster_additional_security_group_ids)
+    customer_node_security_group_ids                   = join(",", var.customer_node_security_group_ids)
+    customer_private_link_security_group_ids           = join(",", var.customer_private_link_security_group_ids)
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      if [ "${var.customer_vpc_id}" != "" ] && [ "${length(var.customer_cluster_additional_security_group_ids)}" -eq "0" ]; then
+        echo "ERROR: customer_cluster_additional_security_group_ids cannot be empty when customer_vpc_id is provided."
+        exit 1
+      fi
+    EOT
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      if [ "${var.customer_vpc_id}" != "" ] && [ "${length(var.customer_node_security_group_ids)}" -eq "0" ]; then
+        echo "ERROR: customer_node_security_group_ids cannot be empty when customer_vpc_id is provided."
+        exit 1
+      fi
+    EOT
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      if [ "${var.customer_vpc_id}" != "" ] && [ "${length(var.customer_private_link_security_group_ids)}" -eq "0" ]; then
+        echo "ERROR: customer_private_link_security_group_ids cannot be empty when customer_vpc_id is provided."
+        exit 1
+      fi
+    EOT
+  }
+}
+
+resource "null_resource" "validate_customer_ecr" {
+  triggers = {
+    ecr_account_id = var.customer_ecr.ecr_account_id
+    ecr_region     = var.customer_ecr.ecr_region
+    ecr_prefix     = var.customer_ecr.ecr_prefix
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      if [ "${var.customer_ecr.ecr_prefix}" = "" ] || [ "${var.customer_ecr.ecr_account_id}" = "" ] || [ "${var.customer_ecr.ecr_region}" = "" ]; then
+        echo "ERROR: ECR prefix, account ID and region cannot be empty"
+        exit 1
+      fi
+    EOT
+  }
+}

--- a/examples/aws-project-byoc-I/variables.tf
+++ b/examples/aws-project-byoc-I/variables.tf
@@ -35,33 +35,18 @@ variable "customer_cluster_additional_security_group_ids" {
   description = "additional security group IDs for the cluster"
   type        = list(string)
   default     = []
-
-  validation {
-    condition     = var.customer_vpc_id == "" || length(var.customer_cluster_additional_security_group_ids) > 0
-    error_message = "customer_cluster_additional_security_group_ids cannot be empty when customer_vpc_id is provided."
-  }
 }
 
 variable "customer_node_security_group_ids" {
   description = "security group IDs for the node group"
   type        = list(string)
   default     = []
-
-  validation {
-    condition     = var.customer_vpc_id == "" || length(var.customer_node_security_group_ids) > 0
-    error_message = "customer_node_security_group_ids cannot be empty when customer_vpc_id is provided."
-  }
 }
 
 variable "customer_private_link_security_group_ids" {
   description = "security group IDs for the private link"
   type        = list(string)
   default     = []
-
-  validation {
-    condition     = var.customer_vpc_id == "" || length(var.customer_private_link_security_group_ids) > 0
-    error_message = "customer_private_link_security_group_ids cannot be empty when customer_vpc_id is provided."
-  }
 }
 
 variable "customer_private_subnet_ids" {
@@ -86,10 +71,6 @@ variable "customer_ecr" {
     ecr_prefix     = string
     }
   )
-  validation {
-    condition     = var.customer_ecr.ecr_prefix != "" && var.customer_ecr.ecr_account_id != "" && var.customer_ecr.ecr_region != ""
-    error_message = "ECR prefix, account ID and region cannot be empty"
-  }
 
   default = {
     ecr_account_id = "965570967084"


### PR DESCRIPTION
This pull request updates the validation logic for several input variables in the `aws-project-byoc-I` Terraform example. It removes native Terraform variable validation blocks and replaces them with `null_resource` resources and `local-exec` provisioners to perform the same checks. This approach improves compatibility with older Terraform versions that do not support variable validation blocks.

Validation logic migration:

* Removed native validation blocks from the variables `customer_cluster_additional_security_group_ids`, `customer_node_security_group_ids`, `customer_private_link_security_group_ids`, and `customer_ecr` in `variables.tf`. [[1]](diffhunk://#diff-01291f5975e01da689379311d10aea39cdb196fd0f72426bda24acbfb20ae11dL38-L64) [[2]](diffhunk://#diff-01291f5975e01da689379311d10aea39cdb196fd0f72426bda24acbfb20ae11dL89-L92)
* Added a new `validations.tf` file that uses `null_resource` resources and shell scripts to enforce the same input checks for security group and ECR-related variables, ensuring compatibility with older Terraform versions.