### PR TITLE
feat(kms): support AWS Customer-Managed Encryption Key (CMEK) support for BYOC-I projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ terraform.rc
 **/rendered-agent.yaml
 **/test-module
 
+
+.notebook/**

--- a/examples/aws-project-byoc-I/README.md
+++ b/examples/aws-project-byoc-I/README.md
@@ -240,7 +240,28 @@ The example automatically creates **4 IAM roles** with specific purposes:
 
 ---
 
-### 6. ECR Integration
+### 6. Encryption (KMS)
+
+#### Custom - Client-Side Encryption (CSE)
+- **Enable AWS CSE with automatic KMS key creation**:
+  ```hcl
+  enable_aws_cse = true
+  ```
+  - **Purpose**: Enables client-side encryption for Milvus data
+  - **Behavior**: Automatically creates a new KMS key for CSE operations
+  - **Output**: `cse_key_arn` - The ARN of the created CSE KMS key
+
+- **Enable AWS CSE with existing KMS key**:
+  ```hcl
+  enable_aws_cse          = true
+  aws_cse_exiting_key_arn = "arn:aws:kms:us-west-2:123456789012:key/12345678-1234-1234-1234-123456789012"
+  ```
+  - **Purpose**: Uses your existing KMS key for client-side encryption
+  - **Note**: The existing key must allow the storage role to use it for encryption/decryption
+
+---
+
+### 7. ECR Integration
 
 #### Default
 - **Default ECR Configuration**:
@@ -275,7 +296,7 @@ The example automatically creates **4 IAM roles** with specific purposes:
 
 ---
 
-### 7. Resource Tagging
+### 8. Resource Tagging
 
 #### Default
 - **Default Tags**: Resources are automatically tagged with:
@@ -355,6 +376,21 @@ custom_tags = {
   Environment = "production"
   Team        = "data-platform"
 }
+```
+
+#### Encryption (KMS)
+```hcl
+# EBS encryption
+enable_ebs_kms  = true
+ebs_kms_key_arn = "arn:aws:kms:region:account:key/key-id"
+
+# S3 encryption
+enable_s3_kms  = true
+s3_kms_key_arn = "arn:aws:kms:region:account:key/key-id"
+
+# Client-side encryption (CSE)
+enable_aws_cse          = true
+aws_cse_exiting_key_arn = "arn:aws:kms:region:account:key/key-id"  # Optional: use existing key
 ```
 
 #### Advanced
@@ -501,6 +537,7 @@ After successful deployment:
 |--------|-------------|
 | `data_plane_id` | BYOC project data plane ID |
 | `project_id` | BYOC project ID |
+| `cse_key_arn` | CSE KMS key ARN (if `enable_aws_cse = true`) |
 
 ## Important Notes
 

--- a/examples/aws-project-byoc-I/terraform.sample.tfvars
+++ b/examples/aws-project-byoc-I/terraform.sample.tfvars
@@ -105,4 +105,9 @@ minimal_roles = {
     name = ""  # Custom name for node role (optional)
     # use_existing_arn = "arn:aws:iam::123456789012:role/your-existing-node-role"  # Use existing role by ARN (optional)
   }
-}
+}# Enable AWS Client-Side Encryption (CSE) for Milvus data
+
+# Enable AWS Client-Side Encryption (CSE) for Milvus data
+# When enabled without aws_cse_exiting_key_arn, a new KMS key will be created automatically
+enable_aws_cse          = false
+aws_cse_exiting_key_arn = ""  # Optional: Use existing KMS key ARN for CSE

--- a/examples/aws-project-byoc-I/variables.tf
+++ b/examples/aws-project-byoc-I/variables.tf
@@ -210,3 +210,15 @@ variable "s3_kms_key_arn" {
   type        = string
   default     = ""
 }
+
+variable "enable_aws_cse" {
+  description = "Enable AWS CSE"
+  type        = bool
+  default     = false
+}
+
+variable "aws_cse_exiting_key_arn" {
+  description = "The ARN of the existing KMS key to use for AWS CSE"
+  type        = string
+  default     = ""
+}

--- a/modules/aws_byoc_i/kms/main.tf
+++ b/modules/aws_byoc_i/kms/main.tf
@@ -1,0 +1,97 @@
+data "aws_caller_identity" "current" {}
+
+locals {
+  create_key  = var.aws_cse_exiting_key_arn == ""
+  cse_key_arn = local.create_key ? aws_kms_key.zilliz_cse[0].arn : var.aws_cse_exiting_key_arn
+}
+
+# Multi-Region symmetric KMS key for Zilliz cluster encryption and decryption
+resource "aws_kms_key" "zilliz_cse" {
+  count = local.create_key ? 1 : 0
+
+  description              = "Multi-Region symmetric KMS key for Zilliz cluster encryption and decryption"
+  key_usage                = "ENCRYPT_DECRYPT"
+  customer_master_key_spec = "SYMMETRIC_DEFAULT"
+  multi_region             = true
+  enable_key_rotation      = true
+
+  tags = {
+    Vendor = "zilliz-byoc"
+  }
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id      = "key-default-1"
+    Statement = [
+      {
+        Sid       = "Enable IAM User Permissions"
+        Effect    = "Allow"
+        Principal = {
+          # 
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_kms_alias" "zilliz_cse" {
+  count = local.create_key ? 1 : 0
+
+  name          = "alias/${var.prefix}-zilliz-cse"
+  target_key_id = aws_kms_key.zilliz_cse[0].key_id
+}
+
+# IAM role for Zilliz cse cross-account access
+resource "aws_iam_role" "zilliz_cse" {
+  name = "${var.prefix}-zilliz-cse-role"
+
+  tags = {
+    Vendor = "zilliz-byoc"
+  }
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = {
+          AWS = var.trust_role_arn
+        }
+        Action    = "sts:AssumeRole"
+        Condition = {
+          StringEquals = {
+            "sts:ExternalId" = var.prefix
+          }
+        }
+      }
+    ]
+  })
+}
+
+# Inline policy granting KMS encrypt/decrypt/describe on the cse key
+resource "aws_iam_role_policy" "zilliz_cse_policy" {
+  name = "${var.prefix}-zilliz-cse-policy"
+  role = aws_iam_role.zilliz_cse.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "kms:Decrypt",
+          "kms:Encrypt",
+          "kms:DescribeKey",
+          "kms:GenerateDataKey",
+          "kms:GenerateDataKeyWithoutPlaintext"
+        ]
+        Resource = [
+          local.cse_key_arn
+        ]
+      }
+    ]
+  })
+}

--- a/modules/aws_byoc_i/kms/output.tf
+++ b/modules/aws_byoc_i/kms/output.tf
@@ -1,0 +1,14 @@
+output "cse_key_arn" {
+  description = "ARN of the KMS CMEK key (created or existing)"
+  value       = local.cse_key_arn
+}
+
+output "cse_role_arn" {
+  description = "ARN of the IAM role for cross-account CMEK access"
+  value       = aws_iam_role.zilliz_cse.arn
+}
+
+output "external_id" {
+  description = "External ID for the role"
+  value       = var.prefix
+}

--- a/modules/aws_byoc_i/kms/variable.tf
+++ b/modules/aws_byoc_i/kms/variable.tf
@@ -1,0 +1,30 @@
+variable "trust_role_arn" {
+  description = "The arn of the trust role"
+  type        = string
+  nullable    = false
+
+  validation {
+    condition     = can(regex("^arn:aws:iam::[0-9]{12}:role/.+$", var.trust_role_arn))
+    error_message = "trust_role_arn must be a valid IAM role ARN (e.g. arn:aws:iam::123456789012:role/MyRole)."
+  }
+}
+
+
+
+variable "prefix" {
+  description = "prefix of the resource name"
+  type        = string
+  nullable    = false
+
+  validation {
+    condition     = length(var.prefix) > 0
+    error_message = "prefix must not be empty."
+  }
+}
+
+
+variable "aws_cse_exiting_key_arn" {
+  description = "ARN of an existing KMS key to use. When set, no new key is created."
+  type        = string
+  nullable    = true
+}


### PR DESCRIPTION
This pull request introduces AWS Customer-Managed Encryption Key (CMEK) support for BYOC-I projects, allowing users to enable AWS Customer-Supplied Encryption (CSE) with either a newly created or existing KMS key. The changes add a new `kms` module, update project and agent resources to support CMEK, and provide new input variables and outputs for managing encryption settings.

**CMEK and KMS Integration:**

* Added a new `kms` module (`modules/aws_byoc_i/kms`) that provisions a multi-region KMS key, alias, IAM role, and role policy for CMEK, or uses an existing key if provided. [[1]](diffhunk://#diff-db3a1553049d953933e5f9a9db5c631965c9df908a3c836da9db39304fde547cR1-R98) [[2]](diffhunk://#diff-04d9606395e2ed3a51c8599771e2d89daa5dae2f27951daaa9d4d3edd51de21dR1-R28)
* Updated the main BYOC-I project example (`examples/aws-project-byoc-I/main.tf`) to conditionally create and configure the `kms` module and inject KMS configuration into the project resource when AWS CSE is enabled. [[1]](diffhunk://#diff-ceb04624b4562bef3d574bc1c348a358186f146c92d9ddbe00f611067d6ad03bR82-R89) [[2]](diffhunk://#diff-ceb04624b4562bef3d574bc1c348a358186f146c92d9ddbe00f611067d6ad03bR119-R143)

**Configuration and Outputs:**

* Added new variables to control CMEK support: `aws_cse_enabled` (toggle), `aws_cse_exiting_key_arn` (existing key ARN), and corresponding documentation. [[1]](diffhunk://#diff-01291f5975e01da689379311d10aea39cdb196fd0f72426bda24acbfb20ae11dR213-R224) [[2]](diffhunk://#diff-04d9606395e2ed3a51c8599771e2d89daa5dae2f27951daaa9d4d3edd51de21dR1-R28)
* Exposed new outputs for CMEK role ARN and other KMS-related values in both the example and the `kms` module. [[1]](diffhunk://#diff-ceb04624b4562bef3d574bc1c348a358186f146c92d9ddbe00f611067d6ad03bR119-R143) [[2]](diffhunk://#diff-740ee46a1d421797559b0b342a720a1a798bac41dbbde3405f4ecaf730941a0aR1-R14)

These changes enable secure, flexible encryption key management for AWS BYOC-I deployments using either managed or user-supplied keys.