### PR TITLE
fix: wire disk_size variable into all EKS launch templates

### DIFF
--- a/modules/aws_byoc_i/eks/eks_nodegroup.tf
+++ b/modules/aws_byoc_i/eks/eks_nodegroup.tf
@@ -51,14 +51,14 @@ resource "aws_launch_template" "core" {
     http_tokens                 = "required"
   }
 
-  dynamic "block_device_mappings" {
-    for_each = var.enable_ebs_kms ? [1] : []
-    content {
-      device_name = "/dev/xvda"
-      ebs {
-        encrypted  = "true"
-        kms_key_id = var.ebs_kms_key_arn
-      }
+  block_device_mappings {
+    device_name = "/dev/xvda"
+    ebs {
+      delete_on_termination = "true"
+      encrypted             = var.enable_ebs_kms ? "true" : "false"
+      kms_key_id            = var.enable_ebs_kms ? var.ebs_kms_key_arn : null
+      volume_size           = var.k8s_node_groups.core.disk_size
+      volume_type           = "gp3"
     }
   }
 
@@ -133,6 +133,7 @@ resource "aws_launch_template" "init" {
     tags = merge({
       "Name"   = "zilliz-byoc-init"
       "Vendor" = "zilliz-byoc"
+
     }, var.custom_tags)
   }
   tag_specifications {
@@ -176,14 +177,14 @@ resource "aws_launch_template" "default" {
     http_tokens                 = "required"
   }
 
-  dynamic "block_device_mappings" {
-    for_each = var.enable_ebs_kms ? [1] : []
-    content {
-      device_name = "/dev/xvda"
-      ebs {
-        encrypted  = "true"
-        kms_key_id = var.ebs_kms_key_arn
-      }
+  block_device_mappings {
+    device_name = "/dev/xvda"
+    ebs {
+      delete_on_termination = "true"
+      encrypted             = var.enable_ebs_kms ? "true" : "false"
+      kms_key_id            = var.enable_ebs_kms ? var.ebs_kms_key_arn : null
+      volume_size           = max(var.k8s_node_groups.index.disk_size, var.k8s_node_groups.fundamental.disk_size)
+      volume_type           = "gp3"
     }
   }
 
@@ -244,7 +245,7 @@ resource "aws_launch_template" "diskann" {
       kms_key_id            = var.enable_ebs_kms ? var.ebs_kms_key_arn : null
       iops                  = 3000
       throughput            = 125
-      volume_size           = 100
+      volume_size           = var.k8s_node_groups.search.disk_size
       volume_type           = "gp3"
     }
   }


### PR DESCRIPTION
## Summary
- `core` launch template: replace `dynamic block_device_mappings` (KMS-only) with static block, add `volume_size = var.k8s_node_groups.core.disk_size`
- `default` launch template (shared by index/fundamental): same fix, `volume_size` uses `max()` of both nodegroups' disk_size
- `diskann` launch template (search): replace hardcoded `100` with `var.k8s_node_groups.search.disk_size`

Previously, core/default templates only applied `block_device_mappings` when `enable_ebs_kms=true`, meaning `disk_size` variable had no effect when KMS was disabled and EKS default disk size was used instead.

## Test plan
- [ ] Verify `disk_size` variable is correctly applied to all nodegroups when `enable_ebs_kms=false`
- [ ] Verify KMS encryption and `disk_size` both take effect when `enable_ebs_kms=true`
- [ ] `terraform plan` shows no unexpected diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)