### PR TITLE
feat: add IAMReadEKSRole permission to byoc-i maintenance policy

### DIFF
--- a/modules/aws_byoc_i/eks/iam-role-maintenance.tf
+++ b/modules/aws_byoc_i/eks/iam-role-maintenance.tf
@@ -306,6 +306,19 @@ resource "aws_iam_policy" "maintenance_policy_2" {
         ]
       },
       {
+        "Sid" : "IAMReadNodeRole",
+        "Effect" : "Allow",
+        "Action" : [
+          "iam:GetRole",
+          "iam:ListAttachedRolePolicies"
+        ],
+        "Resource" : [
+          "arn:aws:iam::*:role/${local.eks_role_name}",
+          "arn:aws:iam::*:role/${local.minimal_node_role_name}",
+          "arn:aws:iam::*:role/aws-service-role/eks-nodegroup.amazonaws.com/AWSServiceRoleForAmazonEKSNodegroup"
+        ]
+      },
+      {
         "Sid" : "S3CheckBucketLocation",
         "Effect" : "Allow",
         "Action" : [


### PR DESCRIPTION
## Summary
- Add `IAMReadEKSNodeRole` statement to `maintenance_policy_2` in `aws_byoc_i` module
- Permissions: `iam:GetRole`, `iam:ListAttachedRolePolicies`
- Required by `CreateNodegroup` — AWS validates node role trust policy during nodegroup creation
- Resource covers both modes:
  - Standard mode: `${prefix_name}-eks-role`
  - Minimal mode: `${prefix_name}-eks-node-role`
  - Plus `AWSServiceRoleForAmazonEKSNodegroup` service-linked role

## Test plan
- [ ] Test `CreateNodegroup` with standard (non-minimal) mode
- [ ] Test `CreateNodegroup` with minimal roles mode