### PR TITLE
Use per-dataplane GCP BYOC-I resource tags

### DIFF
--- a/examples/gcp-project-byoc-I/README.md
+++ b/examples/gcp-project-byoc-I/README.md
@@ -10,7 +10,7 @@ This example provisions a GCP BYOC-I dataplane with customer-managed infrastruct
 - GCP service accounts for GKE nodes, maintenance, storage, and the booter VM
 - Optional Private Service Connect endpoint
 - Short-lived GCE booter VM that uses a dedicated booter service account to install `cloud-agent` into GKE, then self-deletes after a TTL
-- Resource Manager tag `vendor=zilliz-byoc` for tag-scoped booter self-delete permissions by default
+- Per-dataplane Resource Manager tag for tag-scoped booter self-delete permissions by default
 - `zillizcloud_byoc_i_project_agent` and `zillizcloud_byoc_i_project`
 
 ## Requirements
@@ -41,7 +41,7 @@ The booter VM always uses a dedicated booter service account. The Zilliz BYOC or
 
 The booter image is not required in `terraform.tfvars`. Production defaults to `gcr.io/zilliz-public/gcp-byoc-i-booter:latest`; UAT defaults to `gcr.io/zilliz-byoc-uat/gcp-byoc-i-booter:latest`. For development testing only, override `booter_image` locally.
 
-Resource Manager tags are enabled by default. If your Terraform runner cannot manage tags, either set both `vendor_tag_key_id` and `vendor_tag_value_id` to use a pre-created `vendor=zilliz-byoc` tag, or set `enable_resource_manager_tags = false`. With tags enabled, booter self-delete permission is scoped to the exact booter VM instance name plus the Resource Manager tag. When tags are disabled, booter self-delete permission is scoped to the exact booter VM instance name only.
+Resource Manager tags are enabled by default. When no tag IDs are provided, Terraform creates a per-dataplane tag key derived from `data_plane_id` and a `booter` tag value, so multiple BYOC-I dataplanes can be created in the same GCP project without sharing a fixed project-level tag key. If your Terraform runner cannot manage tags, either set both `vendor_tag_key_id` and `vendor_tag_value_id` to use a pre-created tag, or set `enable_resource_manager_tags = false`. With tags enabled, booter self-delete permission is scoped to the exact booter VM instance name plus the Resource Manager tag. When tags are disabled, booter self-delete permission is scoped to the exact booter VM instance name only.
 
 When Private Service Connect is enabled, the example still bootstraps `cloud-agent` through the public regional tunnel host by default, then reports the PSC endpoint IP in `zillizcloud_byoc_i_project`. This avoids blocking first connect while the PSC endpoint is still pending producer acceptance. To force agent bootstrap through PSC, set `agent_server_host` to the `.byoc.` tunnel host.
 

--- a/examples/gcp-project-byoc-I/tags.tf
+++ b/examples/gcp-project-byoc-I/tags.tf
@@ -1,5 +1,12 @@
 locals {
   create_vendor_resource_manager_tag = var.enable_resource_manager_tags && var.vendor_tag_key_id == "" && var.vendor_tag_value_id == ""
+  resource_manager_tag_key_base_name = replace(lower(local.data_plane_id), "/[^a-z0-9-]/", "-")
+  resource_manager_tag_key_short_name = (
+    length(local.resource_manager_tag_key_base_name) <= 63
+    ? local.resource_manager_tag_key_base_name
+    : "${substr(local.resource_manager_tag_key_base_name, 0, 46)}-${substr(sha1(local.resource_manager_tag_key_base_name), 0, 16)}"
+  )
+  resource_manager_tag_value_short_name = "booter"
 
   vendor_tag_key_id = (
     var.enable_resource_manager_tags
@@ -40,8 +47,8 @@ resource "google_tags_tag_key" "vendor" {
   count = local.create_vendor_resource_manager_tag ? 1 : 0
 
   parent      = "projects/${var.gcp_project_id}"
-  short_name  = "vendor"
-  description = "Vendor tag key for Zilliz BYOC-I resources."
+  short_name  = local.resource_manager_tag_key_short_name
+  description = "Resource Manager tag key for this Zilliz BYOC-I deployment."
 
   depends_on = [google_project_service.required]
 }
@@ -50,6 +57,6 @@ resource "google_tags_tag_value" "zilliz_byoc" {
   count = local.create_vendor_resource_manager_tag ? 1 : 0
 
   parent      = google_tags_tag_key.vendor[0].id
-  short_name  = "zilliz-byoc"
-  description = "Zilliz BYOC-I managed resource tag value."
+  short_name  = local.resource_manager_tag_value_short_name
+  description = "Resource Manager tag value for this Zilliz BYOC-I booter VM."
 }

--- a/examples/gcp-project-byoc-I/terraform.sample.tfvars
+++ b/examples/gcp-project-byoc-I/terraform.sample.tfvars
@@ -11,6 +11,7 @@ zilliz_byoc_service_account_email = "org-xxxxxxxxxxxxxxxxxxxxxxxx@zilliz-byoc-pr
 # customer_bucket_name = "zilliz-byoc-gcp-bucket"
 # bucket_force_destroy = true
 # enable_resource_manager_tags = true
+# Leave tag IDs empty to let Terraform create a per-dataplane tag.
 # vendor_tag_key_id = "tagKeys/1234567890"
 # vendor_tag_value_id = "tagValues/1234567890"
 # agent_server_host = "cloud-tunnel.gcp-us-west1.byoc.cloud.zilliz.com"

--- a/examples/gcp-project-byoc-I/variables.tf
+++ b/examples/gcp-project-byoc-I/variables.tf
@@ -173,7 +173,7 @@ variable "enable_resource_manager_tags" {
 }
 
 variable "vendor_tag_key_id" {
-  description = "Optional pre-created Resource Manager tag key ID, for example tagKeys/123. Leave empty to let Terraform create project-scoped vendor=zilliz-byoc tags."
+  description = "Optional pre-created Resource Manager tag key ID, for example tagKeys/123. Leave empty to let Terraform create a per-dataplane tag key."
   type        = string
   default     = ""
 
@@ -184,7 +184,7 @@ variable "vendor_tag_key_id" {
 }
 
 variable "vendor_tag_value_id" {
-  description = "Optional pre-created Resource Manager tag value ID, for example tagValues/456. Leave empty to let Terraform create project-scoped vendor=zilliz-byoc tags."
+  description = "Optional pre-created Resource Manager tag value ID, for example tagValues/456. Leave empty to let Terraform create a per-dataplane booter tag value."
   type        = string
   default     = ""
 


### PR DESCRIPTION
## Summary
- replace the fixed GCP BYOC-I Resource Manager tag key with a per-dataplane tag key derived from data_plane_id
- keep explicit vendor_tag_key_id/vendor_tag_value_id overrides for pre-created tags
- update GCP BYOC-I docs and sample tfvars comments

## Verification
- terraform fmt -check tags.tf variables.tf terraform.sample.tfvars