### PR TITLE
Use infra-agent Workload Identity for GCP BYOC-I management

### DIFF
--- a/examples/gcp-project-byoc-I/README.md
+++ b/examples/gcp-project-byoc-I/README.md
@@ -33,11 +33,11 @@ terraform apply
 
 The booter VM receives the BYOC-I agent token through Terraform-managed VM metadata. This is intentional for v1 and means the token is visible in Terraform state and VM metadata.
 
-The GCP region is read from `zillizcloud_byoc_i_project_settings`. Set `gcp_project_id` and `zilliz_byoc_service_account_email` in `terraform.tfvars`. The service account email is the Zilliz Cloud BYOC service account for your organization.
+The GCP region is read from `zillizcloud_byoc_i_project_settings`. Set `gcp_project_id` in `terraform.tfvars`.
 
 The example grants the storage service account to the fixed BYOC-I Kubernetes service accounts used by Loki and Milvus bootstrap through GKE Workload Identity. It also grants storage Workload Identity access to the target GKE cluster because instance namespaces and service accounts are created at runtime.
 
-The booter VM always uses a dedicated booter service account. The Zilliz BYOC organization service account is only allowed to impersonate the maintenance service account, not the booter service account.
+The booter VM always uses a dedicated booter service account. The Zilliz BYOC organization service account is not granted permission to impersonate the maintenance service account. The in-cluster `infra/infra-agent-sa` Kubernetes service account uses GKE Workload Identity to access the maintenance service account instead.
 
 The booter image is not required in `terraform.tfvars`. Production defaults to `gcr.io/zilliz-public/gcp-byoc-i-booter:latest`; UAT defaults to `gcr.io/zilliz-byoc-uat/gcp-byoc-i-booter:latest`. For development testing only, override `booter_image` locally.
 

--- a/examples/gcp-project-byoc-I/main.tf
+++ b/examples/gcp-project-byoc-I/main.tf
@@ -3,10 +3,6 @@ data "zillizcloud_byoc_i_project_settings" "this" {
   data_plane_id = var.dataplane_id
 }
 
-data "zillizcloud_gcp_service_account" "current" {
-
-}
-
 module "vpc" {
   source = "../../modules/gcp_byoc_i/vpc"
 
@@ -42,7 +38,6 @@ module "iam" {
   gke_location                      = local.gcp_region
   gke_cluster_name                  = local.gke_cluster_name
   storage_bucket_name               = module.gcs.bucket_id
-  zilliz_byoc_service_account_email = data.zillizcloud_gcp_service_account.current.service_account
   gke_node_service_account_name     = var.customer_gke_node_service_account_name
   management_service_account_name   = var.customer_management_service_account_name
   storage_service_account_name      = var.customer_storage_service_account_name

--- a/examples/gcp-project-byoc-I/terraform.sample.tfvars
+++ b/examples/gcp-project-byoc-I/terraform.sample.tfvars
@@ -1,7 +1,6 @@
 project_id                        = "proj-xxxxxxxx"
 dataplane_id                      = "zilliz-byoc-gcp-us-west1-xxxxxxxx"
 gcp_project_id                    = "customer-gcp-project"
-zilliz_byoc_service_account_email = "org-xxxxxxxxxxxxxxxxxxxxxxxx@zilliz-byoc-prod.iam.gserviceaccount.com"
 
 # Optional overrides.
 # gcp_zones = ["us-west1-a", "us-west1-b", "us-west1-c"]

--- a/modules/gcp_byoc_i/iam/iam.tf
+++ b/modules/gcp_byoc_i/iam/iam.tf
@@ -157,12 +157,6 @@ resource "google_service_account_iam_member" "management_can_use_node_sa" {
   member             = "serviceAccount:${google_service_account.management.email}"
 }
 
-resource "google_service_account_iam_member" "zilliz_byoc_can_impersonate_management" {
-  service_account_id = google_service_account.management.name
-  role               = "roles/iam.serviceAccountTokenCreator"
-  member             = "serviceAccount:${var.zilliz_byoc_service_account_email}"
-}
-
 resource "google_project_iam_custom_role" "maintenance_mig_resize" {
   count = var.enable_direct_mig_resize ? 1 : 0
 
@@ -223,6 +217,17 @@ resource "google_service_account_iam_member" "storage_workload_identity" {
   }
 
   service_account_id = google_service_account.storage.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.gcp_project_id}.svc.id.goog[${each.value.namespace}/${each.value.name}]"
+}
+
+resource "google_service_account_iam_member" "management_workload_identity" {
+  for_each = {
+    for ksa in var.management_workload_identity_ksas :
+    "${ksa.namespace}/${ksa.name}" => ksa
+  }
+
+  service_account_id = google_service_account.management.name
   role               = "roles/iam.workloadIdentityUser"
   member             = "serviceAccount:${var.gcp_project_id}.svc.id.goog[${each.value.namespace}/${each.value.name}]"
 }

--- a/modules/gcp_byoc_i/iam/variables.tf
+++ b/modules/gcp_byoc_i/iam/variables.tf
@@ -23,11 +23,6 @@ variable "storage_bucket_name" {
   type        = string
 }
 
-variable "zilliz_byoc_service_account_email" {
-  description = "Zilliz Cloud BYOC service account email allowed to impersonate the maintenance service account."
-  type        = string
-}
-
 variable "gke_node_service_account_name" {
   description = "GKE node service account account_id. Defaults to <prefix_name>-node."
   type        = string
@@ -59,6 +54,20 @@ variable "storage_workload_identity_ksas" {
     name      = string
   }))
   default = []
+}
+
+variable "management_workload_identity_ksas" {
+  description = "Kubernetes service accounts allowed to impersonate management_sa via GKE Workload Identity."
+  type = list(object({
+    namespace = string
+    name      = string
+  }))
+  default = [
+    {
+      namespace = "infra"
+      name      = "infra-agent-sa"
+    }
+  ]
 }
 
 variable "enable_direct_mig_resize" {


### PR DESCRIPTION
## Summary
- remove direct Zilliz GCP service account impersonation of the GCP BYOC-I management service account
- grant GKE Workload Identity access on management_sa to infra/infra-agent-sa
- clean up the GCP BYOC-I example inputs and docs for the new model

## Validation
- git diff --cached --check before commit
- git diff --check