### PR TITLE
Default GCP BYOC-I PSC service attachment

### DIFF
--- a/examples/gcp-project-byoc-I/README.md
+++ b/examples/gcp-project-byoc-I/README.md
@@ -20,7 +20,7 @@ This example provisions a GCP BYOC-I dataplane with customer-managed infrastruct
 - Zilliz Cloud provider version that includes `zillizcloud_byoc_i_project.gcp`
 - A GCP project with the APIs needed for Artifact Registry, Compute Engine, GKE, IAM, Service Usage, and Cloud Storage
 - By default, the Terraform runner needs `roles/resourcemanager.tagAdmin` and `roles/resourcemanager.tagUser` to create and bind Resource Manager tags
-- For Private Service Connect, set `gcp_psc_service_attachment_id` or add the region entry in `modules/conf.yaml`
+- For Private Service Connect, `gcp_psc_service_attachment_id` is optional. When unset, it defaults to `projects/vdc-dev-test/regions/<region>/serviceAttachments/zilliz-byoc-psc` for `env = "UAT"` and `projects/zilliz-public/regions/<region>/serviceAttachments/zilliz-byoc-psc` otherwise.
 
 ## Usage
 
@@ -34,6 +34,8 @@ terraform apply
 The booter VM receives the BYOC-I agent token through Terraform-managed VM metadata. This is intentional for v1 and means the token is visible in Terraform state and VM metadata.
 
 The GCP region is read from `zillizcloud_byoc_i_project_settings`. Set `gcp_project_id` in `terraform.tfvars`.
+
+The PSC service attachment ID can be overridden with `gcp_psc_service_attachment_id`. When it is not set, Terraform builds the ID from the current BYOC-I project region and environment.
 
 The example grants the storage service account to the fixed BYOC-I Kubernetes service accounts used by Loki and Milvus bootstrap through GKE Workload Identity. It also grants storage Workload Identity access to the target GKE cluster because instance namespaces and service accounts are created at runtime.
 

--- a/examples/gcp-project-byoc-I/locals.tf
+++ b/examples/gcp-project-byoc-I/locals.tf
@@ -38,6 +38,12 @@ locals {
   dataplane_suffix = regex("[^-]+$", local.data_plane_id)
   env_domain       = var.env == "UAT" ? "cloud-uat3.zilliz.com" : "cloud.zilliz.com"
   module_config    = yamldecode(file("${path.module}/../../modules/conf.yaml"))
+  psc_service_attachment_project = var.env == "UAT" ? "vdc-dev-test" : "zilliz-public"
+  gcp_psc_service_attachment_id = (
+    var.gcp_psc_service_attachment_id != ""
+    ? var.gcp_psc_service_attachment_id
+    : "projects/${local.psc_service_attachment_project}/regions/${local.gcp_region}/serviceAttachments/zilliz-byoc-psc"
+  )
   agent_image_url  = data.zillizcloud_byoc_i_project_settings.this.op_config.agent_image_url
   gcp_agent_config = try(local.module_config.GCP.agent_config, {})
   gcp_booter_config = try(local.module_config.GCP.booter_config, {})

--- a/examples/gcp-project-byoc-I/main.tf
+++ b/examples/gcp-project-byoc-I/main.tf
@@ -86,7 +86,7 @@ module "private_link" {
   gcp_region            = local.gcp_region
   vpc_name              = module.vpc.vpc_name
   subnet_name           = module.vpc.primary_subnet_name
-  service_attachment_id = var.gcp_psc_service_attachment_id
+  service_attachment_id = local.gcp_psc_service_attachment_id
 
   depends_on = [google_project_service.required, module.vpc]
 }

--- a/examples/gcp-project-byoc-I/terraform.sample.tfvars
+++ b/examples/gcp-project-byoc-I/terraform.sample.tfvars
@@ -4,6 +4,8 @@ gcp_project_id                    = "customer-gcp-project"
 
 # Optional overrides.
 # gcp_zones = ["us-west1-a", "us-west1-b", "us-west1-c"]
+# Defaults to projects/vdc-dev-test/regions/<region>/serviceAttachments/zilliz-byoc-psc when env = "UAT",
+# otherwise projects/zilliz-public/regions/<region>/serviceAttachments/zilliz-byoc-psc.
 # gcp_psc_service_attachment_id = "projects/<producer-project>/regions/us-west1/serviceAttachments/<service-attachment>"
 # customer_vpc_name = "zilliz-byoc-vpc"
 # customer_gke_cluster_name = "zilliz-byoc-gke"

--- a/examples/gcp-project-byoc-I/variables.tf
+++ b/examples/gcp-project-byoc-I/variables.tf
@@ -119,7 +119,7 @@ variable "enable_private_link" {
 }
 
 variable "gcp_psc_service_attachment_id" {
-  description = "Optional PSC service attachment ID. Defaults to modules/conf.yaml for supported regions."
+  description = "Optional PSC service attachment ID. Defaults to projects/<zilliz-project>/regions/<region>/serviceAttachments/zilliz-byoc-psc."
   type        = string
   default     = ""
 }


### PR DESCRIPTION
## Summary
- default GCP BYOC-I PSC service attachment ID from env and project region when no override is provided
- use vdc-dev-test for UAT and zilliz-public otherwise
- update sample tfvars and README docs

## Tests
- Not run