### PR TITLE
Default GCP booter failure self-delete TTL

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -91,8 +91,10 @@ Deploys Zilliz BYOC-I on Google Cloud Platform:
 - VPC-native GKE networking and GCS storage
 - Private GKE cluster and node pools from BYOC-I quota settings
 - Maintenance, storage, node, and booter service accounts
-- VM booter for private-cluster cloud-agent installation
-- Private Service Connect support
+- VM booter for private-cluster cloud-agent installation with configurable failure self-delete TTL
+- Optional Private Service Connect endpoint with environment-based default service attachment
+- Per-dataplane Resource Manager tags for scoped booter self-delete permissions
+- Workload Identity for infra-agent access through the management service account
 
 **Best for**: GCP BYOC-I deployments where the Terraform runner cannot reach the private GKE API server.
 
@@ -143,7 +145,7 @@ Azure deployment with customer-managed resources.
 
 ### AWS Deployment Requirements
 
-See [AWS Requirements.md](./AWS Requirements.md) for detailed AWS deployment requirements including:
+See [AWS-Requirements.md](./AWS-Requirements.md) for detailed AWS deployment requirements including:
 - VPC high availability best practices
 - Private EKS cluster support
 - Security group configurations
@@ -197,7 +199,7 @@ example-name/
 ├── main.tf                # Main Terraform configuration
 ├── variables.tf           # Variable definitions
 ├── provider.tf            # Provider configuration (if applicable)
-├── terraform.tfvars.json  # Example variable values
+├── terraform.tfvars*      # Example variable values, format varies by example
 └── terraform-permissions/ # IAM policy templates (if applicable)
     └── README.md          # Permissions documentation
 ```

--- a/examples/gcp-project-byoc-I/terraform.sample.tfvars
+++ b/examples/gcp-project-byoc-I/terraform.sample.tfvars
@@ -3,10 +3,13 @@ dataplane_id                      = "zilliz-byoc-gcp-us-west1-xxxxxxxx"
 gcp_project_id                    = "customer-gcp-project"
 
 # Optional overrides.
+# env = "Production"
+# enable_private_link = true
 # gcp_zones = ["us-west1-a", "us-west1-b", "us-west1-c"]
 # Defaults to projects/vdc-dev-test/regions/<region>/serviceAttachments/zilliz-byoc-psc when env = "UAT",
 # otherwise projects/zilliz-public/regions/<region>/serviceAttachments/zilliz-byoc-psc.
 # gcp_psc_service_attachment_id = "projects/<producer-project>/regions/us-west1/serviceAttachments/<service-attachment>"
+# booter_failure_self_delete_ttl_seconds = 7200
 # customer_vpc_name = "zilliz-byoc-vpc"
 # customer_gke_cluster_name = "zilliz-byoc-gke"
 # customer_bucket_name = "zilliz-byoc-gcp-bucket"

--- a/examples/gcp-project-byoc-I/variables.tf
+++ b/examples/gcp-project-byoc-I/variables.tf
@@ -133,7 +133,7 @@ variable "booter_machine_type" {
 variable "booter_failure_self_delete_ttl_seconds" {
   description = "Seconds to keep the booter VM after bootstrap failure before self-delete. Set to 0 to delete immediately."
   type        = number
-  default     = 0
+  default     = 7200
 }
 
 variable "agent_server_host" {

--- a/modules/gcp_byoc_i/booter-vm/variables.tf
+++ b/modules/gcp_byoc_i/booter-vm/variables.tf
@@ -94,5 +94,5 @@ variable "self_delete_ttl_seconds" {
 variable "failure_self_delete_ttl_seconds" {
   description = "Seconds to keep the booter VM after bootstrap failure before self-delete. Set to 0 to delete immediately."
   type        = number
-  default     = 0
+  default     = 7200
 }


### PR DESCRIPTION
## Summary
- set GCP BYOC-I booter failure self-delete TTL default to 7200 seconds in the example
- set the booter-vm module default failure TTL to 7200 seconds as well

## Tests
- Not run