### PR TITLE
Use vdc-prod for GCP BYOC-I PSC default

### DIFF
--- a/examples/gcp-project-byoc-I/README.md
+++ b/examples/gcp-project-byoc-I/README.md
@@ -20,7 +20,7 @@ This example provisions a GCP BYOC-I dataplane with customer-managed infrastruct
 - Zilliz Cloud provider version that includes `zillizcloud_byoc_i_project.gcp`
 - A GCP project with the APIs needed for Artifact Registry, Compute Engine, GKE, IAM, Service Usage, and Cloud Storage
 - By default, the Terraform runner needs `roles/resourcemanager.tagAdmin` and `roles/resourcemanager.tagUser` to create and bind Resource Manager tags
-- For Private Service Connect, `gcp_psc_service_attachment_id` is optional. When unset, it defaults to `projects/vdc-dev-test/regions/<region>/serviceAttachments/zilliz-byoc-psc` for `env = "UAT"` and `projects/zilliz-public/regions/<region>/serviceAttachments/zilliz-byoc-psc` otherwise.
+- For Private Service Connect, `gcp_psc_service_attachment_id` is optional. When unset, it defaults to `projects/vdc-dev-test/regions/<region>/serviceAttachments/zilliz-byoc-psc` for `env = "UAT"` and `projects/vdc-prod/regions/<region>/serviceAttachments/zilliz-byoc-psc` otherwise.
 
 ## Usage
 

--- a/examples/gcp-project-byoc-I/locals.tf
+++ b/examples/gcp-project-byoc-I/locals.tf
@@ -38,7 +38,7 @@ locals {
   dataplane_suffix = regex("[^-]+$", local.data_plane_id)
   env_domain       = var.env == "UAT" ? "cloud-uat3.zilliz.com" : "cloud.zilliz.com"
   module_config    = yamldecode(file("${path.module}/../../modules/conf.yaml"))
-  psc_service_attachment_project = var.env == "UAT" ? "vdc-dev-test" : "zilliz-public"
+  psc_service_attachment_project = var.env == "UAT" ? "vdc-dev-test" : "vdc-prod"
   gcp_psc_service_attachment_id = (
     var.gcp_psc_service_attachment_id != ""
     ? var.gcp_psc_service_attachment_id

--- a/examples/gcp-project-byoc-I/terraform.sample.tfvars
+++ b/examples/gcp-project-byoc-I/terraform.sample.tfvars
@@ -7,7 +7,7 @@ gcp_project_id                    = "customer-gcp-project"
 # enable_private_link = true
 # gcp_zones = ["us-west1-a", "us-west1-b", "us-west1-c"]
 # Defaults to projects/vdc-dev-test/regions/<region>/serviceAttachments/zilliz-byoc-psc when env = "UAT",
-# otherwise projects/zilliz-public/regions/<region>/serviceAttachments/zilliz-byoc-psc.
+# otherwise projects/vdc-prod/regions/<region>/serviceAttachments/zilliz-byoc-psc.
 # gcp_psc_service_attachment_id = "projects/<producer-project>/regions/us-west1/serviceAttachments/<service-attachment>"
 # booter_failure_self_delete_ttl_seconds = 7200
 # customer_vpc_name = "zilliz-byoc-vpc"


### PR DESCRIPTION
## Summary
- Change the default production GCP BYOC-I PSC service attachment project from zilliz-public to vdc-prod
- Update the GCP BYOC-I README and sample tfvars to match the new default

## Notes
UAT continues to use vdc-dev-test.