### PR TITLE
Use GCP BYOC production repositories

### DIFF
--- a/examples/gcp-project-byoc-I/README.md
+++ b/examples/gcp-project-byoc-I/README.md
@@ -41,7 +41,7 @@ The example grants the storage service account to the fixed BYOC-I Kubernetes se
 
 The booter VM always uses a dedicated booter service account. The Zilliz BYOC organization service account is not granted permission to impersonate the maintenance service account. The in-cluster `infra/infra-agent-sa` Kubernetes service account uses GKE Workload Identity to access the maintenance service account instead.
 
-The booter image is not required in `terraform.tfvars`. Production defaults to `gcr.io/zilliz-public/gcp-byoc-i-booter:latest`; UAT defaults to `gcr.io/zilliz-byoc-uat/gcp-byoc-i-booter:latest`. For development testing only, override `booter_image` locally.
+The booter image is not required in `terraform.tfvars`. Production defaults to `gcr.io/zilliz-byoc-prod/gcp-byoc-i-booter:latest`; UAT defaults to `gcr.io/zilliz-byoc-uat/gcp-byoc-i-booter:latest`. For development testing only, override `booter_image` locally.
 
 Resource Manager tags are enabled by default. When no tag IDs are provided, Terraform creates a per-dataplane tag key derived from `data_plane_id` and a `booter` tag value, so multiple BYOC-I dataplanes can be created in the same GCP project without sharing a fixed project-level tag key. If your Terraform runner cannot manage tags, either set both `vendor_tag_key_id` and `vendor_tag_value_id` to use a pre-created tag, or set `enable_resource_manager_tags = false`. With tags enabled, booter self-delete permission is scoped to the exact booter VM instance name plus the Resource Manager tag. When tags are disabled, booter self-delete permission is scoped to the exact booter VM instance name only.
 

--- a/modules/conf.yaml
+++ b/modules/conf.yaml
@@ -27,10 +27,10 @@ Azure:
 
 GCP:
   agent_config:
-    repository: gcr.io/zilliz-public/cloud-agent
+    repository: gcr.io/zilliz-byoc-prod/cloud-agent
     uat_repository: gcr.io/zilliz-byoc-uat/cloud-agent
   booter_config:
-    repository: gcr.io/zilliz-public/gcp-byoc-i-booter
+    repository: gcr.io/zilliz-byoc-prod/gcp-byoc-i-booter
     uat_repository: gcr.io/zilliz-byoc-uat/gcp-byoc-i-booter
   private_service_connect:
     service_attachment_ids: {}


### PR DESCRIPTION
## Summary
- Change GCP BYOC-I production cloud-agent repository to gcr.io/zilliz-byoc-prod/cloud-agent
- Change GCP BYOC-I production booter repository to gcr.io/zilliz-byoc-prod/gcp-byoc-i-booter
- Update the GCP BYOC-I README default booter image description

## Notes
UAT repositories continue to use gcr.io/zilliz-byoc-uat.