### PR TITLE
Use production GCP BYOC-I PSC service attachment name

### DIFF
--- a/examples/gcp-project-byoc-I/README.md
+++ b/examples/gcp-project-byoc-I/README.md
@@ -20,7 +20,7 @@ This example provisions a GCP BYOC-I dataplane with customer-managed infrastruct
 - Zilliz Cloud provider version that includes `zillizcloud_byoc_i_project.gcp`
 - A GCP project with the APIs needed for Artifact Registry, Compute Engine, GKE, IAM, Service Usage, and Cloud Storage
 - By default, the Terraform runner needs `roles/resourcemanager.tagAdmin` and `roles/resourcemanager.tagUser` to create and bind Resource Manager tags
-- For Private Service Connect, `gcp_psc_service_attachment_id` is optional. When unset, it defaults to `projects/vdc-dev-test/regions/<region>/serviceAttachments/zilliz-byoc-psc` for `env = "UAT"` and `projects/vdc-prod/regions/<region>/serviceAttachments/zilliz-byoc-psc` otherwise.
+- For Private Service Connect, `gcp_psc_service_attachment_id` is optional. When unset, it defaults to `projects/vdc-dev-test/regions/<region>/serviceAttachments/zilliz-byoc-psc` for `env = "UAT"` and `projects/vdc-prod/regions/<region>/serviceAttachments/zilliz-byoc-psc-service` otherwise.
 
 ## Usage
 

--- a/examples/gcp-project-byoc-I/locals.tf
+++ b/examples/gcp-project-byoc-I/locals.tf
@@ -39,10 +39,11 @@ locals {
   env_domain       = var.env == "UAT" ? "cloud-uat3.zilliz.com" : "cloud.zilliz.com"
   module_config    = yamldecode(file("${path.module}/../../modules/conf.yaml"))
   psc_service_attachment_project = var.env == "UAT" ? "vdc-dev-test" : "vdc-prod"
+  psc_service_attachment_name    = var.env == "UAT" ? "zilliz-byoc-psc" : "zilliz-byoc-psc-service"
   gcp_psc_service_attachment_id = (
     var.gcp_psc_service_attachment_id != ""
     ? var.gcp_psc_service_attachment_id
-    : "projects/${local.psc_service_attachment_project}/regions/${local.gcp_region}/serviceAttachments/zilliz-byoc-psc"
+    : "projects/${local.psc_service_attachment_project}/regions/${local.gcp_region}/serviceAttachments/${local.psc_service_attachment_name}"
   )
   agent_image_url  = data.zillizcloud_byoc_i_project_settings.this.op_config.agent_image_url
   gcp_agent_config = try(local.module_config.GCP.agent_config, {})

--- a/examples/gcp-project-byoc-I/terraform.sample.tfvars
+++ b/examples/gcp-project-byoc-I/terraform.sample.tfvars
@@ -7,7 +7,7 @@ gcp_project_id                    = "customer-gcp-project"
 # enable_private_link = true
 # gcp_zones = ["us-west1-a", "us-west1-b", "us-west1-c"]
 # Defaults to projects/vdc-dev-test/regions/<region>/serviceAttachments/zilliz-byoc-psc when env = "UAT",
-# otherwise projects/vdc-prod/regions/<region>/serviceAttachments/zilliz-byoc-psc.
+# otherwise projects/vdc-prod/regions/<region>/serviceAttachments/zilliz-byoc-psc-service.
 # gcp_psc_service_attachment_id = "projects/<producer-project>/regions/us-west1/serviceAttachments/<service-attachment>"
 # booter_failure_self_delete_ttl_seconds = 7200
 # customer_vpc_name = "zilliz-byoc-vpc"

--- a/examples/gcp-project-byoc-I/variables.tf
+++ b/examples/gcp-project-byoc-I/variables.tf
@@ -119,7 +119,7 @@ variable "enable_private_link" {
 }
 
 variable "gcp_psc_service_attachment_id" {
-  description = "Optional PSC service attachment ID. Defaults to projects/<zilliz-project>/regions/<region>/serviceAttachments/zilliz-byoc-psc."
+  description = "Optional PSC service attachment ID. Defaults by environment and region when unset."
   type        = string
   default     = ""
 }


### PR DESCRIPTION
## Summary
- Use zilliz-byoc-psc-service as the default production PSC service attachment name for GCP BYOC-I
- Keep UAT default as zilliz-byoc-psc
- Update README, sample tfvars, and variable description

## Notes
This aligns the GCP BYOC-I production PSC default with the existing GCP private-link config.