### PR TITLE
Enhance GCP BYOC-I tiered, psc, booter bootstrap & etc

### DIFF
--- a/examples/gcp-project-byoc-I/README.md
+++ b/examples/gcp-project-byoc-I/README.md
@@ -55,6 +55,28 @@ If the provider version has not been released yet, use a local Terraform provide
 
 Before destroying this example, edit `main.tf` and temporarily change the `zillizcloud_byoc_i_project.this` lifecycle protection from `prevent_destroy = true` to `prevent_destroy = false`.
 
+### Keep the GCS Bucket
+
+If you want to keep the GCS bucket and only destroy the other dataplane resources, first remove the bucket resource from this Terraform state:
+
+```bash
+terraform state rm module.gcs.google_storage_bucket.this
+```
+
+Then run destroy:
+
+```bash
+ZILLIZCLOUD_API_KEY=<YourZillizApiKey> \
+terraform destroy \
+  -var="dataplane_id=<YourZillizDataPlaneId>" \
+  -var="project_id=<YourZillizProjectId>" \
+  -var="gcp_project_id=<YourGcpProjectId>"
+```
+
+After `terraform state rm`, Terraform no longer manages the bucket in this state, so destroy will not try to delete it.
+
+### Delete the GCS Bucket
+
 If you want `terraform destroy` to delete the GCS bucket and all objects in it, `bucket_force_destroy = true` must already be applied to the bucket resource before the destroy plan runs. Apply that bucket setting first:
 
 ```bash
@@ -77,11 +99,3 @@ terraform destroy \
   -var="gcp_project_id=<YourGcpProjectId>" \
   -var="bucket_force_destroy=true"
 ```
-
-If you do not want Terraform to delete the GCS bucket, do not rely only on `bucket_force_destroy = false`: Terraform can still delete an empty bucket during destroy. Remove the bucket from Terraform state before running destroy, or move its state to another Terraform workspace/configuration that will continue to manage it:
-
-```bash
-terraform state rm module.gcs.google_storage_bucket.this
-```
-
-After the bucket is removed from this state, run `terraform destroy` with `bucket_force_destroy = false` or omit the variable and use the default value.

--- a/examples/gcp-project-byoc-I/README.md
+++ b/examples/gcp-project-byoc-I/README.md
@@ -51,9 +51,35 @@ If the provider version has not been released yet, use a local Terraform provide
 
 ## Destroy Notes
 
-Terraform will not delete a non-empty GCS bucket unless `bucket_force_destroy` has already been applied to that bucket resource. If you need `terraform destroy` to remove dataplane objects in the bucket, set `bucket_force_destroy = true` before destroy and apply that change first:
+Before destroying this example, edit `main.tf` and temporarily change the `zillizcloud_byoc_i_project.this` lifecycle protection from `prevent_destroy = true` to `prevent_destroy = false`.
+
+If you want `terraform destroy` to delete the GCS bucket and all objects in it, `bucket_force_destroy = true` must already be applied to the bucket resource before the destroy plan runs. Apply that bucket setting first:
 
 ```bash
-terraform apply -target=module.gcs.google_storage_bucket.this
-terraform destroy
+ZILLIZCLOUD_API_KEY=<YourZillizApiKey> \
+terraform apply \
+  -target=module.gcs.google_storage_bucket.this \
+  -var="dataplane_id=<YourZillizDataPlaneId>" \
+  -var="project_id=<YourZillizProjectId>" \
+  -var="gcp_project_id=<YourGcpProjectId>" \
+  -var="bucket_force_destroy=true"
 ```
+
+Then run destroy with the same required variables:
+
+```bash
+ZILLIZCLOUD_API_KEY=<YourZillizApiKey> \
+terraform destroy \
+  -var="dataplane_id=<YourZillizDataPlaneId>" \
+  -var="project_id=<YourZillizProjectId>" \
+  -var="gcp_project_id=<YourGcpProjectId>" \
+  -var="bucket_force_destroy=true"
+```
+
+If you do not want Terraform to delete the GCS bucket, do not rely only on `bucket_force_destroy = false`: Terraform can still delete an empty bucket during destroy. Remove the bucket from Terraform state before running destroy, or move its state to another Terraform workspace/configuration that will continue to manage it:
+
+```bash
+terraform state rm module.gcs.google_storage_bucket.this
+```
+
+After the bucket is removed from this state, run `terraform destroy` with `bucket_force_destroy = false` or omit the variable and use the default value.

--- a/examples/gcp-project-byoc-I/README.md
+++ b/examples/gcp-project-byoc-I/README.md
@@ -45,6 +45,8 @@ The booter VM always uses a dedicated booter service account. The Zilliz BYOC or
 
 The booter image is not required in `terraform.tfvars`. Production defaults to `gcr.io/zilliz-byoc-prod/gcp-byoc-i-booter:latest`; UAT defaults to `gcr.io/zilliz-byoc-uat/gcp-byoc-i-booter:latest`. For development testing only, override `booter_image` locally.
 
+For booter troubleshooting, set `booter_print_serial_logs_on_apply = true` to print the booter VM serial console logs during `terraform apply`. This requires `gcloud` to be installed and authenticated on the Terraform runner.
+
 Resource Manager tags are enabled by default. When no tag IDs are provided, Terraform creates a per-dataplane tag key derived from `data_plane_id` and a `booter` tag value, so multiple BYOC-I dataplanes can be created in the same GCP project without sharing a fixed project-level tag key. If your Terraform runner cannot manage tags, either set both `vendor_tag_key_id` and `vendor_tag_value_id` to use a pre-created tag, or set `enable_resource_manager_tags = false`. With tags enabled, booter self-delete permission is scoped to the exact booter VM instance name plus the Resource Manager tag. When tags are disabled, booter self-delete permission is scoped to the exact booter VM instance name only.
 
 When Private Service Connect is enabled, Terraform passes the PSC endpoint IP to the booter. The booter chart renders `hostAliases` for `cloud-agent` and `cloud-agent-backup`, so the configured `agent_server_host` resolves to the PSC endpoint IP inside those pods. The PSC endpoint IP is also reported in `zillizcloud_byoc_i_project`.

--- a/examples/gcp-project-byoc-I/README.md
+++ b/examples/gcp-project-byoc-I/README.md
@@ -35,6 +35,8 @@ The booter VM receives the BYOC-I agent token through Terraform-managed VM metad
 
 The GCP region is read from `zillizcloud_byoc_i_project_settings`. Set `gcp_project_id` in `terraform.tfvars`.
 
+Default resource names use the prefix `zilliz-dp-<last-12-chars-of-data_plane_id>`. For example, the default VPC, GKE cluster, booter VM, and bucket names are derived from that prefix. If you already deployed this example with older random-suffix names, set the `customer_*` name variables to the existing resource names before applying this version.
+
 The PSC service attachment ID can be overridden with `gcp_psc_service_attachment_id`. When it is not set, Terraform builds the ID from the current BYOC-I project region and environment.
 
 The example grants the storage service account to the fixed BYOC-I Kubernetes service accounts used by Loki and Milvus bootstrap through GKE Workload Identity. It also grants storage Workload Identity access to the target GKE cluster because instance namespaces and service accounts are created at runtime.

--- a/examples/gcp-project-byoc-I/README.md
+++ b/examples/gcp-project-byoc-I/README.md
@@ -47,7 +47,7 @@ The booter image is not required in `terraform.tfvars`. Production defaults to `
 
 Resource Manager tags are enabled by default. When no tag IDs are provided, Terraform creates a per-dataplane tag key derived from `data_plane_id` and a `booter` tag value, so multiple BYOC-I dataplanes can be created in the same GCP project without sharing a fixed project-level tag key. If your Terraform runner cannot manage tags, either set both `vendor_tag_key_id` and `vendor_tag_value_id` to use a pre-created tag, or set `enable_resource_manager_tags = false`. With tags enabled, booter self-delete permission is scoped to the exact booter VM instance name plus the Resource Manager tag. When tags are disabled, booter self-delete permission is scoped to the exact booter VM instance name only.
 
-When Private Service Connect is enabled, the example still bootstraps `cloud-agent` through the public regional tunnel host by default, then reports the PSC endpoint IP in `zillizcloud_byoc_i_project`. This avoids blocking first connect while the PSC endpoint is still pending producer acceptance. To force agent bootstrap through PSC, set `agent_server_host` to the `.byoc.` tunnel host.
+When Private Service Connect is enabled, Terraform passes the PSC endpoint IP to the booter. The booter chart renders `hostAliases` for `cloud-agent` and `cloud-agent-backup`, so the configured `agent_server_host` resolves to the PSC endpoint IP inside those pods. The PSC endpoint IP is also reported in `zillizcloud_byoc_i_project`.
 
 If the provider version has not been released yet, use a local Terraform provider development override that points to a locally built `terraform-provider-zillizcloud`.
 

--- a/examples/gcp-project-byoc-I/locals.tf
+++ b/examples/gcp-project-byoc-I/locals.tf
@@ -73,7 +73,7 @@ locals {
     : "cloud-tunnel.gcp-${local.gcp_region}.${local.env_domain}"
   )
   agent_endpoint_ip = (
-    local.psc_endpoint_ip != null && can(regex("\\.byoc\\.", local.agent_server_host))
+    local.psc_endpoint_ip != null
     ? local.psc_endpoint_ip
     : ""
   )

--- a/examples/gcp-project-byoc-I/locals.tf
+++ b/examples/gcp-project-byoc-I/locals.tf
@@ -1,15 +1,14 @@
-resource "random_id" "short_uuid" {
-  byte_length = 3
-}
-
 locals {
-  short_project_id = substr(data.zillizcloud_byoc_i_project_settings.this.id, 0, 10)
-  prefix_name      = "zilliz-${local.short_project_id}-${random_id.short_uuid.hex}"
-  gcp_region       = trimprefix(data.zillizcloud_byoc_i_project_settings.this.region, "gcp-")
-  gcp_zones        = var.gcp_zones != null ? var.gcp_zones : ["${local.gcp_region}-a", "${local.gcp_region}-b", "${local.gcp_region}-c"]
-
   project_id    = data.zillizcloud_byoc_i_project_settings.this.project_id
   data_plane_id = data.zillizcloud_byoc_i_project_settings.this.data_plane_id
+  data_plane_id_last12 = substr(
+    local.data_plane_id,
+    max(length(local.data_plane_id) - 12, 0),
+    min(length(local.data_plane_id), 12),
+  )
+  prefix_name = "zilliz-dp-${local.data_plane_id_last12}"
+  gcp_region  = trimprefix(data.zillizcloud_byoc_i_project_settings.this.region, "gcp-")
+  gcp_zones   = var.gcp_zones != null ? var.gcp_zones : ["${local.gcp_region}-a", "${local.gcp_region}-b", "${local.gcp_region}-c"]
 
   enable_private_link = var.enable_private_link && data.zillizcloud_byoc_i_project_settings.this.private_link_enabled
 
@@ -35,9 +34,9 @@ locals {
     })
   }
 
-  dataplane_suffix = regex("[^-]+$", local.data_plane_id)
-  env_domain       = var.env == "UAT" ? "cloud-uat3.zilliz.com" : "cloud.zilliz.com"
-  module_config    = yamldecode(file("${path.module}/../../modules/conf.yaml"))
+  dataplane_suffix               = regex("[^-]+$", local.data_plane_id)
+  env_domain                     = var.env == "UAT" ? "cloud-uat3.zilliz.com" : "cloud.zilliz.com"
+  module_config                  = yamldecode(file("${path.module}/../../modules/conf.yaml"))
   psc_service_attachment_project = var.env == "UAT" ? "vdc-dev-test" : "vdc-prod"
   psc_service_attachment_name    = var.env == "UAT" ? "zilliz-byoc-psc" : "zilliz-byoc-psc-service"
   gcp_psc_service_attachment_id = (
@@ -45,8 +44,8 @@ locals {
     ? var.gcp_psc_service_attachment_id
     : "projects/${local.psc_service_attachment_project}/regions/${local.gcp_region}/serviceAttachments/${local.psc_service_attachment_name}"
   )
-  agent_image_url  = data.zillizcloud_byoc_i_project_settings.this.op_config.agent_image_url
-  gcp_agent_config = try(local.module_config.GCP.agent_config, {})
+  agent_image_url   = data.zillizcloud_byoc_i_project_settings.this.op_config.agent_image_url
+  gcp_agent_config  = try(local.module_config.GCP.agent_config, {})
   gcp_booter_config = try(local.module_config.GCP.booter_config, {})
   booter_image_repository = (
     var.env == "UAT"

--- a/examples/gcp-project-byoc-I/main.tf
+++ b/examples/gcp-project-byoc-I/main.tf
@@ -105,6 +105,7 @@ module "booter_vm" {
   booter_image                 = local.booter_image
   machine_type                 = var.booter_machine_type
   failure_self_delete_ttl_seconds = var.booter_failure_self_delete_ttl_seconds
+  print_serial_logs_on_apply      = var.booter_print_serial_logs_on_apply
   gke_cluster_name             = module.gke.cluster_name
   dataplane_id                 = local.data_plane_id
   agent_config                 = local.agent_config

--- a/examples/gcp-project-byoc-I/provider.tf
+++ b/examples/gcp-project-byoc-I/provider.tf
@@ -6,10 +6,6 @@ terraform {
       source  = "hashicorp/google"
       version = "~> 6.32.0"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = ">= 3.0.0"
-    }
     zillizcloud = {
       source  = "zilliztech/zillizcloud"
       version = ">= 0.6.27"

--- a/examples/gcp-project-byoc-I/terraform.sample.tfvars
+++ b/examples/gcp-project-byoc-I/terraform.sample.tfvars
@@ -10,6 +10,7 @@ gcp_project_id                    = "customer-gcp-project"
 # otherwise projects/vdc-prod/regions/<region>/serviceAttachments/zilliz-byoc-psc-service.
 # gcp_psc_service_attachment_id = "projects/<producer-project>/regions/us-west1/serviceAttachments/<service-attachment>"
 # booter_failure_self_delete_ttl_seconds = 7200
+# Default resource names use zilliz-dp-<last-12-chars-of-dataplane_id>. Set these to keep existing names.
 # customer_vpc_name = "zilliz-byoc-vpc"
 # customer_gke_cluster_name = "zilliz-byoc-gke"
 # customer_bucket_name = "zilliz-byoc-gcp-bucket"

--- a/examples/gcp-project-byoc-I/terraform.sample.tfvars
+++ b/examples/gcp-project-byoc-I/terraform.sample.tfvars
@@ -19,5 +19,6 @@ gcp_project_id                    = "customer-gcp-project"
 # Leave tag IDs empty to let Terraform create a per-dataplane tag.
 # vendor_tag_key_id = "tagKeys/1234567890"
 # vendor_tag_value_id = "tagValues/1234567890"
-# agent_server_host = "cloud-tunnel.gcp-us-west1.byoc.cloud.zilliz.com"
+# Usually do not override these unless Zilliz instructs you to use custom tunnel hosts.
+# agent_server_host = "cloud-tunnel.gcp-us-west1.cloud.zilliz.com"
 # agent_tunnel_host = "k8sxxxxxxxx.gcp-us-west1.byoc.cloud.zilliz.com"

--- a/examples/gcp-project-byoc-I/terraform.sample.tfvars
+++ b/examples/gcp-project-byoc-I/terraform.sample.tfvars
@@ -10,6 +10,8 @@ gcp_project_id                    = "customer-gcp-project"
 # otherwise projects/vdc-prod/regions/<region>/serviceAttachments/zilliz-byoc-psc-service.
 # gcp_psc_service_attachment_id = "projects/<producer-project>/regions/us-west1/serviceAttachments/<service-attachment>"
 # booter_failure_self_delete_ttl_seconds = 7200
+# Print booter VM serial console logs during terraform apply. Requires gcloud on the Terraform runner.
+# booter_print_serial_logs_on_apply = true
 # Default resource names use zilliz-dp-<last-12-chars-of-dataplane_id>. Set these to keep existing names.
 # customer_vpc_name = "zilliz-byoc-vpc"
 # customer_gke_cluster_name = "zilliz-byoc-gke"

--- a/examples/gcp-project-byoc-I/variables.tf
+++ b/examples/gcp-project-byoc-I/variables.tf
@@ -136,6 +136,12 @@ variable "booter_failure_self_delete_ttl_seconds" {
   default     = 7200
 }
 
+variable "booter_print_serial_logs_on_apply" {
+  description = "Print booter VM serial console logs during terraform apply for troubleshooting. Requires gcloud on the Terraform runner."
+  type        = bool
+  default     = false
+}
+
 variable "agent_server_host" {
   description = "Optional cloud-agent tunnel server host override."
   type        = string

--- a/modules/gcp_byoc_i/booter-vm/main.tf
+++ b/modules/gcp_byoc_i/booter-vm/main.tf
@@ -49,3 +49,82 @@ resource "google_compute_instance" "this" {
     enable_vtpm                 = true
   }
 }
+
+resource "terraform_data" "serial_console_log" {
+  count = var.print_serial_logs_on_apply ? 1 : 0
+
+  triggers_replace = {
+    instance_id        = google_compute_instance.this.id
+    startup_script_sha = sha256(local.startup_script)
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+
+    environment = {
+      INSTANCE_NAME   = local.instance_name
+      PROJECT         = var.gcp_project_id
+      ZONE            = var.gcp_zone
+      TIMEOUT_SECONDS = tostring(var.serial_log_timeout_seconds)
+      POLL_SECONDS    = "10"
+    }
+
+    command = <<-EOT
+      set -uo pipefail
+
+      if ! command -v gcloud >/dev/null 2>&1; then
+        echo "gcp-booter serial log: gcloud is not installed; skipping serial log streaming"
+        exit 0
+      fi
+
+      tmp_dir="$(mktemp -d)"
+      trap 'rm -rf "$tmp_dir"' EXIT
+      log_file="$tmp_dir/serial.log"
+      error_file="$tmp_dir/error.log"
+      printed_lines=0
+      deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
+
+      echo "gcp-booter serial log: streaming serial port output for $${INSTANCE_NAME} ($${PROJECT}/$${ZONE})"
+
+      while [ "$(date +%s)" -lt "$deadline" ]; do
+        if ! gcloud compute instances get-serial-port-output "$INSTANCE_NAME" \
+          --project="$PROJECT" \
+          --zone="$ZONE" \
+          --port=1 \
+          >"$log_file" 2>"$error_file"; then
+          err="$(cat "$error_file")"
+          if echo "$err" | grep -qiE 'not found|was not found|resource.*notFound'; then
+            echo "gcp-booter serial log: instance is no longer available; stopping serial log streaming"
+            exit 0
+          fi
+          echo "gcp-booter serial log: failed to read serial output: $err"
+          sleep "$POLL_SECONDS"
+          continue
+        fi
+
+        total_lines="$(wc -l <"$log_file" | tr -d ' ')"
+        if [ "$total_lines" -gt "$printed_lines" ]; then
+          tail -n "+$((printed_lines + 1))" "$log_file"
+          printed_lines="$total_lines"
+        fi
+
+        if grep -qE 'zilliz gcp byoc-i booter attempt [0-9]+ result 0' "$log_file"; then
+          echo "gcp-booter serial log: bootstrap success detected"
+          exit 0
+        fi
+
+        if grep -q 'booter failed after 3 attempts' "$log_file"; then
+          echo "gcp-booter serial log: bootstrap failure detected"
+          exit 1
+        fi
+
+        sleep "$POLL_SECONDS"
+      done
+
+      echo "gcp-booter serial log: timed out after $${TIMEOUT_SECONDS}s; continuing without failing apply"
+      exit 0
+    EOT
+  }
+
+  depends_on = [google_compute_instance.this]
+}

--- a/modules/gcp_byoc_i/booter-vm/variables.tf
+++ b/modules/gcp_byoc_i/booter-vm/variables.tf
@@ -88,7 +88,7 @@ variable "resource_manager_tags" {
 variable "self_delete_ttl_seconds" {
   description = "Seconds to keep the booter VM after a successful bootstrap before self-delete."
   type        = number
-  default     = 1800
+  default     = 60
 }
 
 variable "failure_self_delete_ttl_seconds" {

--- a/modules/gcp_byoc_i/booter-vm/variables.tf
+++ b/modules/gcp_byoc_i/booter-vm/variables.tf
@@ -96,3 +96,20 @@ variable "failure_self_delete_ttl_seconds" {
   type        = number
   default     = 7200
 }
+
+variable "print_serial_logs_on_apply" {
+  description = "Print booter VM serial console logs during terraform apply. Requires gcloud on the Terraform runner."
+  type        = bool
+  default     = false
+}
+
+variable "serial_log_timeout_seconds" {
+  description = "Maximum seconds to stream booter VM serial console logs when print_serial_logs_on_apply is enabled."
+  type        = number
+  default     = 1200
+
+  validation {
+    condition     = var.serial_log_timeout_seconds > 0
+    error_message = "serial_log_timeout_seconds must be greater than 0."
+  }
+}

--- a/modules/gcp_byoc_i/gke/locals.tf
+++ b/modules/gcp_byoc_i/gke/locals.tf
@@ -39,6 +39,11 @@ locals {
     }
   }
 
+  node_group_local_ssd_counts = {
+    search = 4
+    tiered = 8
+  }
+
   node_groups = {
     for name, group in var.k8s_node_groups : name => group
     if group.max_size > 0 && contains(keys(local.node_group_labels), name)

--- a/modules/gcp_byoc_i/gke/main.tf
+++ b/modules/gcp_byoc_i/gke/main.tf
@@ -131,9 +131,9 @@ resource "google_container_node_pool" "this" {
     }
 
     dynamic "ephemeral_storage_local_ssd_config" {
-      for_each = each.key == "search" ? [1] : []
+      for_each = contains(keys(local.node_group_local_ssd_counts), each.key) ? [local.node_group_local_ssd_counts[each.key]] : []
       content {
-        local_ssd_count = 4
+        local_ssd_count = ephemeral_storage_local_ssd_config.value
       }
     }
 


### PR DESCRIPTION
## Summary

- support tiered， add configurable local SSD counts for GCP BYOC-I node pools
  - keep `search` node pool at 4 local SSDs
  - configure `tiered` node pool with 8 local SSDs
- switch GCP BYOC-I default resource prefix to `zilliz-dp-<last-12-chars-of-data_plane_id>` and remove the random provider dependency
- pass PSC endpoint IP to the booter whenever Private Service Connect is enabled, so cloud-agent pods can resolve the tunnel server through `hostAliases`
- reduce successful booter VM self-delete TTL from 1800s to 60s
- add optional booter serial console log streaming during `terraform apply` for troubleshooting
- expand GCP BYOC-I docs for resource naming, destroy flows, bucket handling, PSC behavior, and booter debugging
- wait kubectl-proxy container k8sapi ready then invoke control plane create dp api

## Validation

- `terraform init -backend=false`
- `terraform validate`
- `git diff --check`

## Notes

- `booter_print_serial_logs_on_apply` defaults to `false`; when enabled, the Terraform runner must have `gcloud` installed and authenticated.
- Existing deployments that used the old random resource prefix should set `customer_*` name variables before applying this version.