### PR TITLE
Fix AWS BYOC-I booter environment config

### DIFF
--- a/examples/aws-project-byoc-I/main.tf
+++ b/examples/aws-project-byoc-I/main.tf
@@ -53,6 +53,7 @@ module "eks" {
   external_id                  = local.external_id
   agent_config                 = local.agent_config
   enable_private_link          = local.enable_private_link
+  env                          = var.env
   k8s_node_groups              = local.k8s_node_groups
   enable_tiered                = local.enable_tiered
   s3_bucket_id                 = local.s3_bucket_id

--- a/examples/aws-project-byoc-I/terraform.sample.tfvars
+++ b/examples/aws-project-byoc-I/terraform.sample.tfvars
@@ -20,6 +20,9 @@
 # For detailed setup instructions, refer to the README.md file
 #
 
+# Environment name. Defaults to Production. Set to UAT only for UAT dataplanes.
+# env = "Production"
+
 # The ID of the existing customer VPC, otherwise it will create a new VPC if not provided
 customer_vpc_id = "vpc-xxxxxxxxxxxxxxxxx"
 

--- a/examples/aws-project-byoc-I/variables.tf
+++ b/examples/aws-project-byoc-I/variables.tf
@@ -11,6 +11,12 @@ variable "dataplane_id" {
   nullable    = false
 }
 
+variable "env" {
+  description = "Environment name. UAT uses cloud-uat3.zilliz.com, all other values use cloud.zilliz.com."
+  type        = string
+  default     = "Production"
+}
+
 variable "vpc_cidr" {
   description = "The CIDR block for the customer VPC"
   type        = string

--- a/modules/aws_byoc_i/eks/locals.tf
+++ b/modules/aws_byoc_i/eks/locals.tf
@@ -72,6 +72,7 @@ locals {
     EKS_CLUSTER_NAME    = local.eks_cluster_name
     DATAPLANE_ID        = var.dataplane_id
     REGION              = var.region
+    ENV                 = var.env
     AGENT_CONFIG        = local.agent_config_json
     MAINTAINCE_ROLE     = local.maintenance_role.arn
     OP_CONFIG           = jsonencode(local.config)

--- a/modules/aws_byoc_i/eks/variables.tf
+++ b/modules/aws_byoc_i/eks/variables.tf
@@ -65,6 +65,12 @@ variable "enable_private_link" {
   default     = false
 }
 
+variable "env" {
+  description = "Environment name. UAT uses cloud-uat3.zilliz.com, all other values use cloud.zilliz.com."
+  type        = string
+  default     = "Production"
+}
+
 variable "agent_config" {
   description = "Configuration for the agent including server host, auth token, and k8s token"
   type = object({


### PR DESCRIPTION
## Summary
- add an explicit `env` variable for AWS BYOC-I examples and EKS module
- pass `env` into the booter `BOOT_CONFIG` as `ENV`
- document the default production value in sample tfvars

## Why
The AWS booter should not infer UAT by scanning the entire boot config, because unrelated config such as image registry strings can contain `uat` and make production deployments connect to UAT tunnel hosts.

## Validation
- `git diff --check`