### PR TITLE
Add GCP BYOC-I PSC private DNS

### DIFF
--- a/examples/gcp-project-byoc-I/README.md
+++ b/examples/gcp-project-byoc-I/README.md
@@ -20,7 +20,7 @@ This example provisions a GCP BYOC-I dataplane with customer-managed infrastruct
 - Zilliz Cloud provider version that includes `zillizcloud_byoc_i_project.gcp`
 - A GCP project with the APIs needed for Artifact Registry, Compute Engine, Cloud DNS, GKE, IAM, Service Usage, and Cloud Storage
 - By default, the Terraform runner needs `roles/resourcemanager.tagAdmin` and `roles/resourcemanager.tagUser` to create and bind Resource Manager tags
-- For Private Service Connect, `gcp_psc_service_attachment_id` is optional. When unset, it defaults to `projects/vdc-dev-test/regions/<region>/serviceAttachments/zilliz-byoc-psc-dns` for `env = "UAT"` and `projects/vdc-prod/regions/<region>/serviceAttachments/zilliz-byoc-psc-service` otherwise.
+- For Private Service Connect, `gcp_psc_service_attachment_id` is optional. When unset, it defaults to `projects/vdc-dev-test/regions/<region>/serviceAttachments/zilliz-byoc-psc-dns` for `env = "UAT"` and `projects/vdc-prod/regions/<region>/serviceAttachments/zilliz-byoc-psc-dns` otherwise.
 
 ## Usage
 

--- a/examples/gcp-project-byoc-I/README.md
+++ b/examples/gcp-project-byoc-I/README.md
@@ -18,9 +18,9 @@ This example provisions a GCP BYOC-I dataplane with customer-managed infrastruct
 - Terraform `>= 1.6.0`
 - Google provider `~> 6.32.0`
 - Zilliz Cloud provider version that includes `zillizcloud_byoc_i_project.gcp`
-- A GCP project with the APIs needed for Artifact Registry, Compute Engine, GKE, IAM, Service Usage, and Cloud Storage
+- A GCP project with the APIs needed for Artifact Registry, Compute Engine, Cloud DNS, GKE, IAM, Service Usage, and Cloud Storage
 - By default, the Terraform runner needs `roles/resourcemanager.tagAdmin` and `roles/resourcemanager.tagUser` to create and bind Resource Manager tags
-- For Private Service Connect, `gcp_psc_service_attachment_id` is optional. When unset, it defaults to `projects/vdc-dev-test/regions/<region>/serviceAttachments/zilliz-byoc-psc` for `env = "UAT"` and `projects/vdc-prod/regions/<region>/serviceAttachments/zilliz-byoc-psc-service` otherwise.
+- For Private Service Connect, `gcp_psc_service_attachment_id` is optional. When unset, it defaults to `projects/vdc-dev-test/regions/<region>/serviceAttachments/zilliz-byoc-psc-dns` for `env = "UAT"` and `projects/vdc-prod/regions/<region>/serviceAttachments/zilliz-byoc-psc-service` otherwise.
 
 ## Usage
 
@@ -49,7 +49,7 @@ For booter troubleshooting, set `booter_print_serial_logs_on_apply = true` to pr
 
 Resource Manager tags are enabled by default. When no tag IDs are provided, Terraform creates a per-dataplane tag key derived from `data_plane_id` and a `booter` tag value, so multiple BYOC-I dataplanes can be created in the same GCP project without sharing a fixed project-level tag key. If your Terraform runner cannot manage tags, either set both `vendor_tag_key_id` and `vendor_tag_value_id` to use a pre-created tag, or set `enable_resource_manager_tags = false`. With tags enabled, booter self-delete permission is scoped to the exact booter VM instance name plus the Resource Manager tag. When tags are disabled, booter self-delete permission is scoped to the exact booter VM instance name only.
 
-When Private Service Connect is enabled, Terraform passes the PSC endpoint IP to the booter. The booter chart renders `hostAliases` for `cloud-agent` and `cloud-agent-backup`, so the configured `agent_server_host` resolves to the PSC endpoint IP inside those pods. The PSC endpoint IP is also reported in `zillizcloud_byoc_i_project`.
+When Private Service Connect is enabled, the default `agent_server_host` uses `cloud-tunnel.gcp-<region>.byoc.<env_domain>`. Terraform creates Cloud DNS private A records for `cloud-tunnel.gcp-<region>.byoc.<env_domain>` and `cloud-open-api.gcp-<region>.byoc.<env_domain>` that point to the PSC endpoint IP. The booter chart also renders `hostAliases` for `cloud-agent` and `cloud-agent-backup`, so the configured `agent_server_host` resolves to the PSC endpoint IP inside those pods. Set `enable_private_dns = false` if the customer VPC already manages these private records externally.
 
 If the provider version has not been released yet, use a local Terraform provider development override that points to a locally built `terraform-provider-zillizcloud`.
 

--- a/examples/gcp-project-byoc-I/locals.tf
+++ b/examples/gcp-project-byoc-I/locals.tf
@@ -38,12 +38,22 @@ locals {
   env_domain                     = var.env == "UAT" ? "cloud-uat3.zilliz.com" : "cloud.zilliz.com"
   module_config                  = yamldecode(file("${path.module}/../../modules/conf.yaml"))
   psc_service_attachment_project = var.env == "UAT" ? "vdc-dev-test" : "vdc-prod"
-  psc_service_attachment_name    = var.env == "UAT" ? "zilliz-byoc-psc" : "zilliz-byoc-psc-service"
+  psc_service_attachment_name    = var.env == "UAT" ? "zilliz-byoc-psc-dns" : "zilliz-byoc-psc-service"
   gcp_psc_service_attachment_id = (
     var.gcp_psc_service_attachment_id != ""
     ? var.gcp_psc_service_attachment_id
     : "projects/${local.psc_service_attachment_project}/regions/${local.gcp_region}/serviceAttachments/${local.psc_service_attachment_name}"
   )
+  gcp_private_service_domain = "gcp-${local.gcp_region}.byoc.${local.env_domain}"
+  psc_private_dns_domain = (
+    var.gcp_psc_private_dns_domain != ""
+    ? var.gcp_psc_private_dns_domain
+    : "${local.gcp_private_service_domain}."
+  )
+  psc_private_dns_record_names = length(var.gcp_psc_private_dns_record_names) > 0 ? var.gcp_psc_private_dns_record_names : [
+    "cloud-tunnel.${local.gcp_private_service_domain}.",
+    "cloud-open-api.${local.gcp_private_service_domain}.",
+  ]
   agent_image_url   = data.zillizcloud_byoc_i_project_settings.this.op_config.agent_image_url
   gcp_agent_config  = try(local.module_config.GCP.agent_config, {})
   gcp_booter_config = try(local.module_config.GCP.booter_config, {})
@@ -70,7 +80,7 @@ locals {
   agent_server_host = (
     var.agent_server_host != ""
     ? var.agent_server_host
-    : "cloud-tunnel.gcp-${local.gcp_region}.${local.env_domain}"
+    : "cloud-tunnel.gcp-${local.gcp_region}${local.enable_private_link ? ".byoc" : ""}.${local.env_domain}"
   )
   agent_endpoint_ip = (
     local.psc_endpoint_ip != null

--- a/examples/gcp-project-byoc-I/locals.tf
+++ b/examples/gcp-project-byoc-I/locals.tf
@@ -38,7 +38,7 @@ locals {
   env_domain                     = var.env == "UAT" ? "cloud-uat3.zilliz.com" : "cloud.zilliz.com"
   module_config                  = yamldecode(file("${path.module}/../../modules/conf.yaml"))
   psc_service_attachment_project = var.env == "UAT" ? "vdc-dev-test" : "vdc-prod"
-  psc_service_attachment_name    = var.env == "UAT" ? "zilliz-byoc-psc-dns" : "zilliz-byoc-psc-service"
+  psc_service_attachment_name    = "zilliz-byoc-psc-dns"
   gcp_psc_service_attachment_id = (
     var.gcp_psc_service_attachment_id != ""
     ? var.gcp_psc_service_attachment_id

--- a/examples/gcp-project-byoc-I/main.tf
+++ b/examples/gcp-project-byoc-I/main.tf
@@ -87,6 +87,9 @@ module "private_link" {
   vpc_name              = module.vpc.vpc_name
   subnet_name           = module.vpc.primary_subnet_name
   service_attachment_id = local.gcp_psc_service_attachment_id
+  enable_private_dns    = var.enable_private_dns
+  private_dns_domain    = local.psc_private_dns_domain
+  private_dns_record_names = local.psc_private_dns_record_names
 
   depends_on = [google_project_service.required, module.vpc]
 }

--- a/examples/gcp-project-byoc-I/services.tf
+++ b/examples/gcp-project-byoc-I/services.tf
@@ -4,6 +4,7 @@ locals {
     "artifactregistry.googleapis.com",
     "compute.googleapis.com",
     "container.googleapis.com",
+    "dns.googleapis.com",
     "iam.googleapis.com",
     "storage.googleapis.com",
   ])

--- a/examples/gcp-project-byoc-I/terraform.sample.tfvars
+++ b/examples/gcp-project-byoc-I/terraform.sample.tfvars
@@ -6,9 +6,15 @@ gcp_project_id                    = "customer-gcp-project"
 # env = "Production"
 # enable_private_link = true
 # gcp_zones = ["us-west1-a", "us-west1-b", "us-west1-c"]
-# Defaults to projects/vdc-dev-test/regions/<region>/serviceAttachments/zilliz-byoc-psc when env = "UAT",
+# Defaults to projects/vdc-dev-test/regions/<region>/serviceAttachments/zilliz-byoc-psc-dns when env = "UAT",
 # otherwise projects/vdc-prod/regions/<region>/serviceAttachments/zilliz-byoc-psc-service.
 # gcp_psc_service_attachment_id = "projects/<producer-project>/regions/us-west1/serviceAttachments/<service-attachment>"
+# enable_private_dns = true
+# gcp_psc_private_dns_domain = "gcp-us-west1.byoc.cloud.zilliz.com."
+# gcp_psc_private_dns_record_names = [
+#   "cloud-tunnel.gcp-us-west1.byoc.cloud.zilliz.com.",
+#   "cloud-open-api.gcp-us-west1.byoc.cloud.zilliz.com.",
+# ]
 # booter_failure_self_delete_ttl_seconds = 7200
 # Print booter VM serial console logs during terraform apply. Requires gcloud on the Terraform runner.
 # booter_print_serial_logs_on_apply = true
@@ -22,5 +28,5 @@ gcp_project_id                    = "customer-gcp-project"
 # vendor_tag_key_id = "tagKeys/1234567890"
 # vendor_tag_value_id = "tagValues/1234567890"
 # Usually do not override these unless Zilliz instructs you to use custom tunnel hosts.
-# agent_server_host = "cloud-tunnel.gcp-us-west1.cloud.zilliz.com"
+# agent_server_host = "cloud-tunnel.gcp-us-west1.byoc.cloud.zilliz.com"
 # agent_tunnel_host = "k8sxxxxxxxx.gcp-us-west1.byoc.cloud.zilliz.com"

--- a/examples/gcp-project-byoc-I/terraform.sample.tfvars
+++ b/examples/gcp-project-byoc-I/terraform.sample.tfvars
@@ -7,7 +7,7 @@ gcp_project_id                    = "customer-gcp-project"
 # enable_private_link = true
 # gcp_zones = ["us-west1-a", "us-west1-b", "us-west1-c"]
 # Defaults to projects/vdc-dev-test/regions/<region>/serviceAttachments/zilliz-byoc-psc-dns when env = "UAT",
-# otherwise projects/vdc-prod/regions/<region>/serviceAttachments/zilliz-byoc-psc-service.
+# otherwise projects/vdc-prod/regions/<region>/serviceAttachments/zilliz-byoc-psc-dns.
 # gcp_psc_service_attachment_id = "projects/<producer-project>/regions/us-west1/serviceAttachments/<service-attachment>"
 # enable_private_dns = true
 # gcp_psc_private_dns_domain = "gcp-us-west1.byoc.cloud.zilliz.com."

--- a/examples/gcp-project-byoc-I/variables.tf
+++ b/examples/gcp-project-byoc-I/variables.tf
@@ -124,6 +124,24 @@ variable "gcp_psc_service_attachment_id" {
   default     = ""
 }
 
+variable "enable_private_dns" {
+  description = "Whether to create Cloud DNS private records for Private Service Connect service hosts."
+  type        = bool
+  default     = true
+}
+
+variable "gcp_psc_private_dns_domain" {
+  description = "Optional Cloud DNS private zone DNS name for PSC service hosts. Defaults to gcp-<region>.byoc.<env_domain>."
+  type        = string
+  default     = ""
+}
+
+variable "gcp_psc_private_dns_record_names" {
+  description = "Optional PSC private DNS A record FQDNs. Defaults to cloud-tunnel and cloud-open-api under the PSC private DNS domain."
+  type        = list(string)
+  default     = []
+}
+
 variable "booter_machine_type" {
   description = "Booter VM machine type."
   type        = string

--- a/modules/gcp_byoc_i/private-link/locals.tf
+++ b/modules/gcp_byoc_i/private-link/locals.tf
@@ -1,4 +1,6 @@
 locals {
   config                = yamldecode(file("${path.module}/../../conf.yaml"))
   service_attachment_id = var.service_attachment_id != "" ? var.service_attachment_id : try(local.config.GCP.private_service_connect.service_attachment_ids[var.gcp_region], "")
+  private_dns_domain    = var.private_dns_domain != "" ? "${trimsuffix(var.private_dns_domain, ".")}." : ""
+  private_dns_zone_name = var.private_dns_zone_name != "" ? var.private_dns_zone_name : substr("${var.prefix_name}-psc-dns", 0, 63)
 }

--- a/modules/gcp_byoc_i/private-link/main.tf
+++ b/modules/gcp_byoc_i/private-link/main.tf
@@ -30,3 +30,28 @@ resource "google_compute_forwarding_rule" "byoc_endpoint" {
     }
   }
 }
+
+resource "google_dns_managed_zone" "psc" {
+  count = var.enable_private_dns && local.private_dns_domain != "" ? 1 : 0
+
+  name        = local.private_dns_zone_name
+  dns_name    = local.private_dns_domain
+  description = "Private DNS zone for Zilliz BYOC Private Service Connect hosts."
+  visibility  = "private"
+
+  private_visibility_config {
+    networks {
+      network_url = data.google_compute_network.this.id
+    }
+  }
+}
+
+resource "google_dns_record_set" "psc" {
+  for_each = var.enable_private_dns && local.private_dns_domain != "" ? toset(var.private_dns_record_names) : toset([])
+
+  name         = endswith(each.value, ".") ? each.value : "${each.value}."
+  managed_zone = google_dns_managed_zone.psc[0].name
+  type         = "A"
+  ttl          = 300
+  rrdatas      = [google_compute_address.psc.address]
+}

--- a/modules/gcp_byoc_i/private-link/outputs.tf
+++ b/modules/gcp_byoc_i/private-link/outputs.tf
@@ -5,3 +5,11 @@ output "byoc_endpoint_id" {
 output "byoc_endpoint_ip" {
   value = google_compute_address.psc.address
 }
+
+output "private_dns_zone_name" {
+  value = try(google_dns_managed_zone.psc[0].name, null)
+}
+
+output "private_dns_record_names" {
+  value = [for record in google_dns_record_set.psc : record.name]
+}

--- a/modules/gcp_byoc_i/private-link/variables.tf
+++ b/modules/gcp_byoc_i/private-link/variables.tf
@@ -23,3 +23,27 @@ variable "service_attachment_id" {
   type        = string
   default     = ""
 }
+
+variable "enable_private_dns" {
+  description = "Whether to create Cloud DNS private records for PSC service hosts."
+  type        = bool
+  default     = true
+}
+
+variable "private_dns_zone_name" {
+  description = "Optional Cloud DNS managed zone name for PSC private records."
+  type        = string
+  default     = ""
+}
+
+variable "private_dns_domain" {
+  description = "Cloud DNS private zone DNS name for PSC service hosts."
+  type        = string
+  default     = ""
+}
+
+variable "private_dns_record_names" {
+  description = "PSC private DNS A record FQDNs that resolve to the PSC endpoint IP."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## Summary
- switch the default UAT GCP BYOC-I PSC service attachment to `zilliz-byoc-psc-dns`
- default private-link tunnel host to the `.byoc.` domain
- create Cloud DNS private A records for `cloud-tunnel` and `cloud-open-api` pointing to the PSC endpoint IP
- add variables to override or disable PSC private DNS management

## Validation
- `terraform -chdir=examples/gcp-project-byoc-I validate`