### PR TITLE
Expose GCP BYOC-I GKE master CIDR

### DIFF
--- a/examples/gcp-project-byoc-I/README.md
+++ b/examples/gcp-project-byoc-I/README.md
@@ -37,6 +37,8 @@ The GCP region is read from `zillizcloud_byoc_i_project_settings`. Set `gcp_proj
 
 Default resource names use the prefix `zilliz-dp-<last-12-chars-of-data_plane_id>`. For example, the default VPC, GKE cluster, booter VM, and bucket names are derived from that prefix. If you already deployed this example with older random-suffix names, set the `customer_*` name variables to the existing resource names before applying this version.
 
+If multiple GCP BYOC-I VPCs need VPC Peering, configure non-overlapping `vpc_cidr` values and unique GKE private control plane ranges with `master_ipv4_cidr_block`. The default control plane range is `172.16.0.0/28`; a second peered environment can use a different `/28`, such as `172.16.0.16/28`.
+
 The PSC service attachment ID can be overridden with `gcp_psc_service_attachment_id`. When it is not set, Terraform builds the ID from the current BYOC-I project region and environment.
 
 The example grants the storage service account to the fixed BYOC-I Kubernetes service accounts used by Loki and Milvus bootstrap through GKE Workload Identity. It also grants storage Workload Identity access to the target GKE cluster because instance namespaces and service accounts are created at runtime.

--- a/examples/gcp-project-byoc-I/main.tf
+++ b/examples/gcp-project-byoc-I/main.tf
@@ -67,6 +67,7 @@ module "gke" {
   gke_node_sa_email        = module.iam.gke_node_sa_email
   k8s_node_groups          = local.k8s_node_groups
   kubernetes_version       = var.kubernetes_version
+  master_ipv4_cidr_block   = var.master_ipv4_cidr_block
   labels                   = local.common_labels
   master_authorized_networks = [
     {

--- a/examples/gcp-project-byoc-I/terraform.sample.tfvars
+++ b/examples/gcp-project-byoc-I/terraform.sample.tfvars
@@ -3,6 +3,9 @@ dataplane_id                      = "zilliz-byoc-gcp-us-west1-xxxxxxxx"
 gcp_project_id                    = "customer-gcp-project"
 
 # Optional overrides.
+# vpc_cidr = "10.0.0.0/16"
+# Use a unique /28 when peering multiple BYOC-I VPCs.
+# master_ipv4_cidr_block = "172.16.0.0/28"
 # env = "Production"
 # enable_private_link = true
 # gcp_zones = ["us-west1-a", "us-west1-b", "us-west1-c"]

--- a/examples/gcp-project-byoc-I/variables.tf
+++ b/examples/gcp-project-byoc-I/variables.tf
@@ -184,6 +184,12 @@ variable "kubernetes_version" {
   default     = null
 }
 
+variable "master_ipv4_cidr_block" {
+  description = "CIDR block for the private GKE control plane. Use a unique /28 when peering multiple BYOC-I VPCs."
+  type        = string
+  default     = "172.16.0.0/28"
+}
+
 variable "enable_direct_mig_resize" {
   description = "Enable direct GKE-managed MIG resize permissions for maintenance_sa. Required for node group scale operations."
   type        = bool


### PR DESCRIPTION
## Summary
- expose `master_ipv4_cidr_block` in the GCP BYOC-I example
- pass the value through to the GKE module
- document using unique /28 GKE private control plane ranges when peering multiple BYOC-I VPCs

## Why
GCP VPC Peering rejects overlapping ranges, including the GKE private control plane peering subnet. Multiple BYOC-I environments currently default to `172.16.0.0/28`, so new peered environments need a configurable master CIDR.

## Validation
- `terraform -chdir=examples/gcp-project-byoc-I validate`