### PR TITLE
Add GCP BYOC-I peering network outputs

### DIFF
--- a/examples/gcp-project-byoc-I/README.md
+++ b/examples/gcp-project-byoc-I/README.md
@@ -39,6 +39,8 @@ Default resource names use the prefix `zilliz-dp-<last-12-chars-of-data_plane_id
 
 If multiple GCP BYOC-I VPCs need VPC Peering, configure non-overlapping `vpc_cidr` values and unique GKE private control plane ranges with `master_ipv4_cidr_block`. The default control plane range is `172.16.0.0/28`; a second peered environment can use a different `/28`, such as `172.16.0.16/28`.
 
+The example outputs `primary_subnet_cidr`, `pod_subnet_cidr`, `service_subnet_cidr`, `lb_subnet_cidr`, and `master_ipv4_cidr_block` to make VPC Peering overlap checks and firewall source range setup explicit.
+
 The PSC service attachment ID can be overridden with `gcp_psc_service_attachment_id`. When it is not set, Terraform builds the ID from the current BYOC-I project region and environment.
 
 The example grants the storage service account to the fixed BYOC-I Kubernetes service accounts used by Loki and Milvus bootstrap through GKE Workload Identity. It also grants storage Workload Identity access to the target GKE cluster because instance namespaces and service accounts are created at runtime.

--- a/examples/gcp-project-byoc-I/outputs.tf
+++ b/examples/gcp-project-byoc-I/outputs.tf
@@ -34,6 +34,30 @@ output "booter_vm_name" {
   value = try(module.booter_vm[0].instance_name, null)
 }
 
+output "vpc_cidr" {
+  value = var.vpc_cidr
+}
+
+output "primary_subnet_cidr" {
+  value = module.vpc.primary_subnet_cidr
+}
+
+output "pod_subnet_cidr" {
+  value = module.vpc.pod_subnet_cidr
+}
+
+output "service_subnet_cidr" {
+  value = module.vpc.service_subnet_cidr
+}
+
+output "lb_subnet_cidr" {
+  value = module.vpc.lb_subnet_cidr
+}
+
+output "master_ipv4_cidr_block" {
+  value = var.master_ipv4_cidr_block
+}
+
 output "psc_endpoint_ip" {
   value = local.psc_endpoint_ip
 }

--- a/examples/gcp-project-byoc-I/variables.tf
+++ b/examples/gcp-project-byoc-I/variables.tf
@@ -188,6 +188,11 @@ variable "master_ipv4_cidr_block" {
   description = "CIDR block for the private GKE control plane. Use a unique /28 when peering multiple BYOC-I VPCs."
   type        = string
   default     = "172.16.0.0/28"
+
+  validation {
+    condition     = can(cidrhost(var.master_ipv4_cidr_block, 0)) && tonumber(split("/", var.master_ipv4_cidr_block)[1]) == 28
+    error_message = "master_ipv4_cidr_block must be a valid /28 CIDR block."
+  }
 }
 
 variable "enable_direct_mig_resize" {

--- a/modules/gcp_byoc_i/gke/variables.tf
+++ b/modules/gcp_byoc_i/gke/variables.tf
@@ -65,6 +65,11 @@ variable "master_ipv4_cidr_block" {
   description = "CIDR block for the private GKE control plane."
   type        = string
   default     = "172.16.0.0/28"
+
+  validation {
+    condition     = can(cidrhost(var.master_ipv4_cidr_block, 0)) && tonumber(split("/", var.master_ipv4_cidr_block)[1]) == 28
+    error_message = "master_ipv4_cidr_block must be a valid /28 CIDR block."
+  }
 }
 
 variable "master_authorized_networks" {

--- a/modules/gcp_byoc_i/vpc/outputs.tf
+++ b/modules/gcp_byoc_i/vpc/outputs.tf
@@ -26,6 +26,18 @@ output "primary_subnet_cidr" {
   value = local.primary_subnet_cidr
 }
 
+output "pod_subnet_cidr" {
+  value = local.pod_subnet_cidr
+}
+
+output "service_subnet_cidr" {
+  value = local.service_subnet_cidr
+}
+
+output "lb_subnet_cidr" {
+  value = local.lb_subnet_cidr
+}
+
 output "pod_subnet_name" {
   value = local.pod_subnet_name
 }


### PR DESCRIPTION
## Summary
- output GCP BYOC-I primary, pod, service, LB, VPC, and GKE master CIDR values for peering checks
- add /28 validation for `master_ipv4_cidr_block` in the example and GKE module
- document the outputs used for VPC Peering overlap checks and firewall source ranges

## Validation
- `terraform -chdir=examples/gcp-project-byoc-I validate`