### PR TITLE
fix(byoc-i): support Kite storage identities

### DIFF
--- a/modules/aws_byoc_i/eks/IAM README.md
+++ b/modules/aws_byoc_i/eks/IAM README.md
@@ -12,8 +12,8 @@ The AWS BYOC-I EKS module creates four distinct IAM roles, each designed for spe
 |-----------|---------|-------------------|----------------|
 | **EKS Cluster Role** | Combined EKS cluster and node management (based on [AWS EKS cluster role](https://docs.aws.amazon.com/eks/latest/userguide/cluster-iam-role.html) and [AWS EKS node role](https://docs.aws.amazon.com/eks/latest/userguide/create-node-role.html)) | `eks.amazonaws.com`, `eks-nodegroup.amazonaws.com`, `ec2.amazonaws.com` | EKS cluster operations, node group management, ECR access, assume maintenance role for initialization |
 | **EKS Add-on Role** | AWS Load Balancer Controller, EBS CSI Driver, Cluster Autoscaler | OIDC Federation (kube-system service accounts) | Load balancer management, volume operations, auto-scaling |
-| **Maintenance Role** | EKS cluster and node group version upgrades, cluster administration (tag-restricted scope) | OIDC Federation (infra agent), EKS Cluster Role | Node group management, EC2 operations, version upgrades, allow EKS role to assume |
-| **Storage Role** | S3 bucket access for Milvus, index-pool, and Loki | OIDC Federation (Milvus, Loki, index-pool) | S3 object read/write for Milvus, index-pool, and Loki  |
+| **Maintenance Role** | EKS cluster and node group version upgrades, cluster administration (tag-restricted scope) | OIDC Federation (infra agent), EKS Cluster Role | Node group management, EC2 operations, version upgrades, and narrowly scoped storage-role trust reconciliation |
+| **Storage Role** | S3 bucket access for Milvus, index-pool, Loki, and Kite | OIDC Federation (Milvus, Loki, index-pool, Kite) | S3 object read/write for Milvus, index-pool, Loki, and Kite |
 
 ## Role Dependencies
 
@@ -119,6 +119,10 @@ graph TD
   - Allow EKS cluster role to assume with external ID validation
   - Enable delegated operations from EKS cluster
 
+- **Storage Role Trust Reconciliation**:
+  - Read and update only this dataplane's storage-role trust policy
+  - Allow the infra agent to add the fixed Kite workload identities idempotently
+
 **Use Cases**:
 - EKS cluster and node group version upgrades
 - Automated cluster maintenance and updates
@@ -128,13 +132,15 @@ graph TD
 
 ### 4. Storage Role (`storage_role`)
 
-**Purpose**: S3 bucket access for Milvus, index-pool, and Loki data services
+**Purpose**: S3 bucket access for Milvus, index-pool, Loki, and Kite data services
 
 **Principal Services**:
 - OIDC Federation for Milvus and related services:
   - `system:serviceaccount:milvus-*:milvus*`
   - `system:serviceaccount:loki:loki*`
   - `system:serviceaccount:index-pool:milvus*`
+  - `system:serviceaccount:vectorlake-kite:kite-coordinator`
+  - `system:serviceaccount:vectorlake-kite-pool:kite-index-pool-sa`
 
 **Key Permissions**:
 - **S3 Operations**:
@@ -146,6 +152,7 @@ graph TD
 - Milvus vector database data read/write
 - Index pool data read/write operations
 - Loki log aggregation data read/write
+- Kite coordinator and index-pool data read/write
 - Backup and restore operations for all data services
 
 ## Security Features

--- a/modules/aws_byoc_i/eks/iam-role-maintenance.tf
+++ b/modules/aws_byoc_i/eks/iam-role-maintenance.tf
@@ -319,6 +319,15 @@ resource "aws_iam_policy" "maintenance_policy_2" {
         ]
       },
       {
+        "Sid" : "IAMReconcileStorageRoleTrust",
+        "Effect" : "Allow",
+        "Action" : [
+          "iam:GetRole",
+          "iam:UpdateAssumeRolePolicy"
+        ],
+        "Resource" : aws_iam_role.storage_role.arn
+      },
+      {
         "Sid" : "S3CheckBucketLocation",
         "Effect" : "Allow",
         "Action" : [
@@ -329,4 +338,3 @@ resource "aws_iam_policy" "maintenance_policy_2" {
     ]
   })
 }
-

--- a/modules/aws_byoc_i/eks/iam-role-storage.tf
+++ b/modules/aws_byoc_i/eks/iam-role-storage.tf
@@ -26,7 +26,9 @@ resource "aws_iam_role" "storage_role" {
             "${local.eks_oidc_url}:sub" : [
               "system:serviceaccount:milvus-*:milvus*",
               "system:serviceaccount:loki:loki*",
-              "system:serviceaccount:index-pool:milvus*"
+              "system:serviceaccount:index-pool:milvus*",
+              "system:serviceaccount:vectorlake-kite:kite-coordinator",
+              "system:serviceaccount:vectorlake-kite-pool:kite-index-pool-sa"
             ]
           }
         }
@@ -100,4 +102,4 @@ resource "aws_iam_role_policy_attachment" "s3_kms_policy_attachment" {
   count      = var.enable_s3_kms ? 1 : 0
   policy_arn = aws_iam_policy.s3_kms_policy[0].arn
   role       = aws_iam_role.storage_role.name
-} 
+}


### PR DESCRIPTION
## Summary

### AWS BYOC-I

- include the Kite coordinator and index-pool service accounts in newly created storage-role trust policies
- grant the maintenance role only `iam:GetRole` and `iam:UpdateAssumeRolePolicy` on the exact storage role
- keep customer trust customizations intact while the companion infra-agent reconciles existing roles additively

### GCP BYOC-I

- always merge `vectorlake-kite/kite-coordinator` and `vectorlake-kite-pool/kite-index-pool-sa` into the storage service account Workload Identity members
- keep caller-provided identities and stable Terraform resource addresses
- retain the cluster-scoped principalSet grant for runtime instance namespaces
- document the explicit Kite grants

## Existing dataplanes

AWS roles are repaired by the companion infra-agent after the maintenance-policy update is applied. GCP dataplanes receive the two explicit IAM members when customers rerun `terraform apply`.

## Validation

- OpenTofu `fmt -check -diff`
- isolated `tofu init -backend=false` and `tofu validate` for `modules/gcp_byoc_i/iam`
- `git diff --check`

CloudFormation is intentionally out of scope because BYOC-I is provisioned through these Terraform modules.