### PR TITLE
feat(gcp-byoc-i): grant Kite workload identities

### DIFF
--- a/examples/gcp-project-byoc-I/README.md
+++ b/examples/gcp-project-byoc-I/README.md
@@ -43,7 +43,7 @@ The example outputs `primary_subnet_cidr`, `pod_subnet_cidr`, `service_subnet_ci
 
 The PSC service attachment ID can be overridden with `gcp_psc_service_attachment_id`. When it is not set, Terraform builds the ID from the current BYOC-I project region and environment.
 
-The example grants the storage service account to the fixed BYOC-I Kubernetes service accounts used by Loki and Milvus bootstrap through GKE Workload Identity. It also grants storage Workload Identity access to the target GKE cluster because instance namespaces and service accounts are created at runtime.
+The IAM module always grants the storage service account to `vectorlake-kite/kite-coordinator` and `vectorlake-kite-pool/kite-index-pool-sa`. The example also grants the fixed BYOC-I Kubernetes service accounts used by Loki and Milvus bootstrap through GKE Workload Identity. The target GKE cluster keeps its cluster-scoped storage Workload Identity grant because instance namespaces and service accounts are created at runtime.
 
 The booter VM always uses a dedicated booter service account. The Zilliz BYOC organization service account is not granted permission to impersonate the maintenance service account. The in-cluster `infra/infra-agent-sa` Kubernetes service account uses GKE Workload Identity to access the maintenance service account instead.
 

--- a/modules/gcp_byoc_i/iam/iam.tf
+++ b/modules/gcp_byoc_i/iam/iam.tf
@@ -216,10 +216,7 @@ resource "google_project_iam_member" "storage_bucket_viewer" {
 }
 
 resource "google_service_account_iam_member" "storage_workload_identity" {
-  for_each = {
-    for ksa in var.storage_workload_identity_ksas :
-    "${ksa.namespace}/${ksa.name}" => ksa
-  }
+  for_each = local.storage_workload_identity_ksas
 
   service_account_id = google_service_account.storage.name
   role               = "roles/iam.workloadIdentityUser"

--- a/modules/gcp_byoc_i/iam/locals.tf
+++ b/modules/gcp_byoc_i/iam/locals.tf
@@ -7,6 +7,30 @@ locals {
   role_suffix_raw    = replace(title(replace(var.prefix_name, "-", " ")), " ", "")
   role_suffix        = substr(local.role_suffix_raw, 0, 20)
 
+  # Keep fixed Kite identities explicit for auditable plans and old dataplane
+  # backfills. The cluster-scoped grant below remains necessary for runtime
+  # instance namespaces whose Kubernetes service accounts are not known here.
+  required_storage_workload_identity_ksas = [
+    {
+      namespace = "vectorlake-kite"
+      name      = "kite-coordinator"
+    },
+    {
+      namespace = "vectorlake-kite-pool"
+      name      = "kite-index-pool-sa"
+    },
+  ]
+  storage_workload_identity_ksas = merge(
+    {
+      for ksa in var.storage_workload_identity_ksas :
+      "${ksa.namespace}/${ksa.name}" => ksa
+    },
+    {
+      for ksa in local.required_storage_workload_identity_ksas :
+      "${ksa.namespace}/${ksa.name}" => ksa
+    },
+  )
+
   storage_cluster_workload_identity_member = "principalSet://iam.googleapis.com/projects/${data.google_project.this.number}/locations/global/workloadIdentityPools/${var.gcp_project_id}.svc.id.goog/kubernetes.cluster/https://container.googleapis.com/v1/projects/${var.gcp_project_id}/locations/${var.gke_location}/clusters/${var.gke_cluster_name}"
 
   # GKE truncates the cluster-name portion of managed instance group names based on node pool name length.

--- a/modules/gcp_byoc_i/iam/variables.tf
+++ b/modules/gcp_byoc_i/iam/variables.tf
@@ -48,7 +48,7 @@ variable "booter_service_account_name" {
 }
 
 variable "storage_workload_identity_ksas" {
-  description = "Kubernetes service accounts allowed to impersonate storage_sa via GKE Workload Identity."
+  description = "Additional Kubernetes service accounts allowed to impersonate storage_sa via GKE Workload Identity. Required Kite service accounts are always included by the module."
   type = list(object({
     namespace = string
     name      = string


### PR DESCRIPTION
## Summary

- always merge `vectorlake-kite/kite-coordinator` and `vectorlake-kite-pool/kite-index-pool-sa` into the GCP BYOC-I storage service account Workload Identity members
- preserve caller-provided identities and existing Terraform resource addresses
- retain the cluster-scoped principalSet grant for runtime-created instance namespaces
- document the explicit, auditable Kite grants

## Existing dataplanes

The cluster-scoped grant already covers current GCP BYOC-I clusters. These explicit members make the fixed Kite contract visible in Terraform plans and backfill older module revisions when customers rerun `terraform apply`.

## Validation

- OpenTofu `fmt -check -diff`
- isolated `tofu init -backend=false` and `tofu validate` for `modules/gcp_byoc_i/iam`
- `git diff --check`

## Related

AWS BYOC-I support was merged in #150. CloudFormation is intentionally out of scope because BYOC-I is provisioned through the customer Terraform modules.