### PR TITLE
feat: support custom GCP BYOC-I image repository

### DIFF
--- a/examples/gcp-project-byoc-I/README.md
+++ b/examples/gcp-project-byoc-I/README.md
@@ -71,7 +71,13 @@ grant_gcs_kms_key_iam = false
 
 The KMS key location must be compatible with the bucket location. Changing the bucket default KMS key affects new objects written after the change; existing objects are not automatically re-encrypted.
 
-The booter image is not required in `terraform.tfvars`. Production defaults to `gcr.io/zilliz-byoc-prod/gcp-byoc-i-booter:latest`; UAT defaults to `gcr.io/zilliz-byoc-uat/gcp-byoc-i-booter:latest`. For development testing only, override `booter_image` locally.
+The booter image is not required in `terraform.tfvars`. Production defaults to `gcr.io/zilliz-byoc-prod/gcp-byoc-i-booter:latest`; UAT defaults to `gcr.io/zilliz-byoc-uat/gcp-byoc-i-booter:latest`. To use a customer-owned image repository for both the booter and cloud-agent images, set `image_repo_url` to the repository base URL without image name or tag:
+
+```hcl
+image_repo_url = "us-docker.pkg.dev/<gcp-project-id>/<repository>"
+```
+
+Terraform will use `<image_repo_url>/gcp-byoc-i-booter:latest` for the booter VM and `<image_repo_url>/cloud-agent:<agent_tag>` for cloud-agent when the Zilliz project settings provide an agent tag. If `booter_image` is set, it remains a full-image override for the booter and takes precedence over `image_repo_url`.
 
 For booter troubleshooting, set `booter_print_serial_logs_on_apply = true` to print the booter VM serial console logs during `terraform apply`. This requires `gcloud` to be installed and authenticated on the Terraform runner.
 

--- a/examples/gcp-project-byoc-I/locals.tf
+++ b/examples/gcp-project-byoc-I/locals.tf
@@ -55,12 +55,22 @@ locals {
     "cloud-open-api.${local.gcp_private_service_domain}.",
   ]
   agent_image_url   = data.zillizcloud_byoc_i_project_settings.this.op_config.agent_image_url
+  agent_image_tag = (
+    can(regex("/", local.agent_image_url)) && can(regex(":", local.agent_image_url))
+    ? element(split(":", local.agent_image_url), length(split(":", local.agent_image_url)) - 1)
+    : local.agent_image_url
+  )
   gcp_agent_config  = try(local.module_config.GCP.agent_config, {})
   gcp_booter_config = try(local.module_config.GCP.booter_config, {})
+  image_repo_url    = trimsuffix(trimspace(var.image_repo_url), "/")
   booter_image_repository = (
-    var.env == "UAT"
-    ? try(local.gcp_booter_config.uat_repository, local.gcp_booter_config.repository)
-    : local.gcp_booter_config.repository
+    local.image_repo_url != ""
+    ? "${local.image_repo_url}/gcp-byoc-i-booter"
+    : (
+      var.env == "UAT"
+      ? try(local.gcp_booter_config.uat_repository, local.gcp_booter_config.repository)
+      : local.gcp_booter_config.repository
+    )
   )
   booter_image = (
     var.booter_image != ""
@@ -68,14 +78,22 @@ locals {
     : "${local.booter_image_repository}:latest"
   )
   agent_image_repository = (
-    var.env == "UAT"
-    ? try(local.gcp_agent_config.uat_repository, try(local.gcp_agent_config.repository, local.module_config.agent_config.repository))
-    : try(local.gcp_agent_config.repository, local.module_config.agent_config.repository)
+    local.image_repo_url != ""
+    ? "${local.image_repo_url}/cloud-agent"
+    : (
+      var.env == "UAT"
+      ? try(local.gcp_agent_config.uat_repository, try(local.gcp_agent_config.repository, local.module_config.agent_config.repository))
+      : try(local.gcp_agent_config.repository, local.module_config.agent_config.repository)
+    )
   )
   agent_image = (
-    can(regex("/", local.agent_image_url))
-    ? local.agent_image_url
-    : "${local.agent_image_repository}:${local.agent_image_url}"
+    local.image_repo_url != ""
+    ? "${local.agent_image_repository}:${local.agent_image_tag}"
+    : (
+      can(regex("/", local.agent_image_url))
+      ? local.agent_image_url
+      : "${local.agent_image_repository}:${local.agent_image_url}"
+    )
   )
   agent_server_host = (
     var.agent_server_host != ""

--- a/examples/gcp-project-byoc-I/terraform.sample.tfvars
+++ b/examples/gcp-project-byoc-I/terraform.sample.tfvars
@@ -18,6 +18,9 @@ gcp_project_id = "customer-gcp-project"
 #   "cloud-tunnel.gcp-us-west1.byoc.cloud.zilliz.com.",
 #   "cloud-open-api.gcp-us-west1.byoc.cloud.zilliz.com.",
 # ]
+# Optional image repository base URL for BYOC-I booter and cloud-agent images, without image name or tag.
+# Terraform uses <image_repo_url>/gcp-byoc-i-booter:latest and <image_repo_url>/cloud-agent:<agent_tag>.
+# image_repo_url = "us-docker.pkg.dev/customer-gcp-project/byoc-images"
 # booter_failure_self_delete_ttl_seconds = 7200
 # Print booter VM serial console logs during terraform apply. Requires gcloud on the Terraform runner.
 # booter_print_serial_logs_on_apply = true

--- a/examples/gcp-project-byoc-I/variables.tf
+++ b/examples/gcp-project-byoc-I/variables.tf
@@ -16,6 +16,12 @@ variable "gcp_project_id" {
   nullable    = false
 }
 
+variable "image_repo_url" {
+  description = "Optional image repository base URL for BYOC-I booter and cloud-agent images, without image name or tag. For example: us-docker.pkg.dev/<project>/<repository>."
+  type        = string
+  default     = ""
+}
+
 variable "booter_image" {
   description = "Optional container image for the GCP-capable BYOC-I booter. Defaults by env when unset."
   type        = string


### PR DESCRIPTION
## Summary
- add `image_repo_url` for the GCP BYOC-I example
- use the custom repository to build booter and cloud-agent image paths
- document the new variable in README and sample tfvars

## Validation
- `terraform validate -no-color` in `examples/gcp-project-byoc-I`

## Notes
- `booter_image` remains the highest-priority full-image override for the booter VM.
- `image_repo_url` should be a repository base URL without image name or tag.
