### PR TITLE
feat: support existing Shared VPC and GKE for GCP BYOC-I

### DIFF
--- a/examples/gcp-project-byoc-I/README.md
+++ b/examples/gcp-project-byoc-I/README.md
@@ -4,9 +4,9 @@ This example provisions a GCP BYOC-I dataplane with customer-managed infrastruct
 
 ## What It Creates
 
-- VPC-native GKE networking, Cloud NAT, and firewall rules
+- VPC-native GKE networking, Cloud NAT, and firewall rules, unless an existing Shared VPC is configured
 - GCS bucket for dataplane storage
-- GKE private regional cluster and node pools from BYOC-I quota settings
+- GKE private regional cluster and node pools from BYOC-I quota settings, unless an existing GKE cluster is configured
 - GCP service accounts for GKE nodes, maintenance, storage, and the booter VM
 - Optional Private Service Connect endpoint
 - Short-lived GCE booter VM that uses a dedicated booter service account to install `cloud-agent` into GKE, then self-deletes after a TTL
@@ -34,6 +34,46 @@ terraform apply
 The booter VM receives the BYOC-I agent token through Terraform-managed VM metadata. This is intentional for v1 and means the token is visible in Terraform state and VM metadata.
 
 The GCP region is read from `zillizcloud_byoc_i_project_settings`. Set `gcp_project_id` in `terraform.tfvars`.
+
+### Existing Shared VPC and GKE
+
+Use `existing_network` and `existing_gke` to attach BYOC-I to a customer-owned Shared VPC and regional GKE cluster without importing or managing those resources:
+
+```hcl
+gcp_project_id = "customer-service-project"
+
+existing_network = {
+  network_project_id           = "customer-network-host-project"
+  vpc_name                     = "shared-vpc"
+  primary_subnet_name          = "shared-vpc-us-west1-primary"
+  pod_secondary_range_name     = "shared-vpc-us-west1-pods"
+  service_secondary_range_name = "shared-vpc-us-west1-services"
+  lb_subnet_name               = "shared-vpc-us-west1-proxy-only"
+}
+
+existing_gke = {
+  cluster_name               = "customer-gke"
+  node_service_account_email = "gke-node@customer-service-project.iam.gserviceaccount.com"
+}
+```
+
+The Shared VPC network and subnets live in `existing_network.network_project_id`. The existing GKE cluster, GCS bucket, booter VM, and BYOC-I service accounts live in `gcp_project_id`. Terraform reads the existing VPC, subnets, cluster, and node pools but does not add the VPC or GKE resources to state. It reuses the configured node service account and manages the IAM grants required by BYOC-I.
+
+The existing infrastructure must satisfy these requirements:
+
+- The GKE cluster is regional, is in the BYOC-I settings region, and uses the configured Shared VPC primary subnet.
+- The cluster is VPC-native, uses private nodes and a private endpoint, and has Workload Identity enabled as `<gcp_project_id>.svc.id.goog`.
+- The primary subnet contains the configured pod and service secondary ranges.
+- `lb_subnet_name` is an active `REGIONAL_MANAGED_PROXY` proxy-only subnet in the same region and VPC.
+- Required node pools already exist with the logical names returned by the BYOC-I quota, normally `core`, `fundamental`, `search`, `index`, and optionally `tiered`.
+- Required node pools use `existing_gke.node_service_account_email` and the labels defined by the [GKE module](../../modules/gcp_byoc_i/gke/locals.tf).
+- Private nodes have working egress for required Google APIs and container registries.
+
+Before apply, grant the Terraform runner sufficient read access to the host project. When Private Service Connect is enabled, the service project must be allowed to use the Shared VPC subnet. When `enable_private_dns = true`, Terraform creates the PSC private DNS zone in the Shared VPC host project, so the runner also needs permission to manage Cloud DNS there.
+
+`existing_gke` requires `existing_network`. Existing zonal GKE clusters are not supported. The existing VPC, subnets, GKE cluster, and node pools are not destroyed by `terraform destroy`; only resources created by this example are managed by Terraform.
+
+Do not enable `existing_network` or `existing_gke` for VPC/GKE resources already managed by the same Terraform state. Changing an existing deployment from managed resources to data sources requires a separate state-migration procedure; otherwise Terraform plans to destroy the formerly managed resources.
 
 Default resource names use the prefix `zilliz-dp-<last-12-chars-of-data_plane_id>`. For example, the default VPC, GKE cluster, booter VM, and bucket names are derived from that prefix. If you already deployed this example with older random-suffix names, set the `customer_*` name variables to the existing resource names before applying this version.
 

--- a/examples/gcp-project-byoc-I/existing.tf
+++ b/examples/gcp-project-byoc-I/existing.tf
@@ -1,0 +1,114 @@
+data "google_compute_network" "existing" {
+  count = local.is_existing_network ? 1 : 0
+
+  project = var.existing_network.network_project_id
+  name    = var.existing_network.vpc_name
+}
+
+data "google_compute_subnetwork" "existing_primary" {
+  count = local.is_existing_network ? 1 : 0
+
+  project = var.existing_network.network_project_id
+  region  = local.gcp_region
+  name    = var.existing_network.primary_subnet_name
+}
+
+data "google_compute_subnetwork" "existing_lb" {
+  count = local.is_existing_network ? 1 : 0
+
+  project = var.existing_network.network_project_id
+  region  = local.gcp_region
+  name    = var.existing_network.lb_subnet_name
+}
+
+data "google_container_cluster" "existing" {
+  count = local.is_existing_gke ? 1 : 0
+
+  project  = var.gcp_project_id
+  location = local.gcp_region
+  name     = var.existing_gke.cluster_name
+}
+
+resource "terraform_data" "existing_infrastructure_validation" {
+  input = {
+    existing_network = local.is_existing_network
+    existing_gke     = local.is_existing_gke
+  }
+
+  lifecycle {
+    precondition {
+      condition     = !local.is_existing_gke || local.is_existing_network
+      error_message = "existing_gke requires existing_network because an existing GKE cluster cannot use the VPC created by this configuration."
+    }
+
+    precondition {
+      condition = local.is_existing_network ? (
+        basename(data.google_compute_subnetwork.existing_primary[0].network) == data.google_compute_network.existing[0].name &&
+        basename(data.google_compute_subnetwork.existing_lb[0].network) == data.google_compute_network.existing[0].name
+      ) : true
+      error_message = "The existing primary and load-balancer subnets must belong to existing_network.vpc_name."
+    }
+
+    precondition {
+      condition = local.is_existing_network ? (
+        contains(keys(local.existing_primary_secondary_ranges), var.existing_network.pod_secondary_range_name) &&
+        contains(keys(local.existing_primary_secondary_ranges), var.existing_network.service_secondary_range_name)
+      ) : true
+      error_message = "The existing primary subnet must contain the configured pod and service secondary ranges."
+    }
+
+    precondition {
+      condition = local.is_existing_gke && local.is_existing_network ? (
+        data.google_container_cluster.existing[0].location == local.gcp_region &&
+        length(data.google_container_cluster.existing[0].node_locations) > 0 &&
+        basename(data.google_container_cluster.existing[0].network) == data.google_compute_network.existing[0].name &&
+        basename(data.google_container_cluster.existing[0].subnetwork) == data.google_compute_subnetwork.existing_primary[0].name
+      ) : true
+      error_message = "The existing GKE cluster must be regional, in the BYOC-I region, and attached to the configured Shared VPC primary subnet."
+    }
+
+    precondition {
+      condition = local.is_existing_gke ? (
+        data.google_container_cluster.existing[0].networking_mode == "VPC_NATIVE" &&
+        try(data.google_container_cluster.existing[0].private_cluster_config[0].enable_private_nodes, false) &&
+        try(data.google_container_cluster.existing[0].private_cluster_config[0].enable_private_endpoint, false) &&
+        try(data.google_container_cluster.existing[0].workload_identity_config[0].workload_pool, "") == "${var.gcp_project_id}.svc.id.goog"
+      ) : true
+      error_message = "The existing GKE cluster must be VPC-native, use private nodes and a private endpoint, and enable Workload Identity for the service project."
+    }
+
+    precondition {
+      condition = local.is_existing_gke && local.is_existing_network ? (
+        try(data.google_container_cluster.existing[0].ip_allocation_policy[0].cluster_secondary_range_name, "") == var.existing_network.pod_secondary_range_name &&
+        try(data.google_container_cluster.existing[0].ip_allocation_policy[0].services_secondary_range_name, "") == var.existing_network.service_secondary_range_name
+      ) : true
+      error_message = "The existing GKE cluster must use the configured pod and service secondary ranges."
+    }
+
+    precondition {
+      condition = local.is_existing_gke ? length(setsubtract(
+        local.required_node_pool_names,
+        toset(keys(local.existing_node_pools)),
+      )) == 0 : true
+      error_message = "The existing GKE cluster is missing required BYOC-I node pools: ${join(", ", sort(tolist(setsubtract(local.required_node_pool_names, toset(keys(local.existing_node_pools))))))}. Required pool names are derived from the Zilliz BYOC-I project quota."
+    }
+
+    precondition {
+      condition = local.is_existing_gke ? alltrue([
+        for node_pool_name in local.required_node_pool_names :
+        try(local.existing_node_pools[node_pool_name].node_config[0].service_account, "") == var.existing_gke.node_service_account_email
+      ]) : true
+      error_message = "All required existing GKE node pools must use existing_gke.node_service_account_email."
+    }
+
+    precondition {
+      condition = local.is_existing_gke ? alltrue(flatten([
+        for node_pool_name in local.required_node_pool_names : [
+          for label_name, label_value in local.required_node_pool_labels[node_pool_name] :
+          try(local.existing_node_pools[node_pool_name].node_config[0].labels[label_name], "") == label_value
+        ]
+      ])) : true
+      error_message = "The existing GKE node pools do not contain all required Zilliz BYOC-I node labels."
+    }
+  }
+}

--- a/examples/gcp-project-byoc-I/locals.tf
+++ b/examples/gcp-project-byoc-I/locals.tf
@@ -6,14 +6,19 @@ locals {
     max(length(local.data_plane_id) - 12, 0),
     min(length(local.data_plane_id), 12),
   )
-  prefix_name = "zilliz-dp-${local.data_plane_id_last12}"
-  gcp_region  = trimprefix(data.zillizcloud_byoc_i_project_settings.this.region, "gcp-")
-  gcp_zones   = var.gcp_zones != null ? var.gcp_zones : ["${local.gcp_region}-a", "${local.gcp_region}-b", "${local.gcp_region}-c"]
+  prefix_name       = "zilliz-dp-${local.data_plane_id_last12}"
+  gcp_region        = trimprefix(data.zillizcloud_byoc_i_project_settings.this.region, "gcp-")
+  default_gcp_zones = var.gcp_zones != null ? var.gcp_zones : ["${local.gcp_region}-a", "${local.gcp_region}-b", "${local.gcp_region}-c"]
 
   enable_private_link = var.enable_private_link && data.zillizcloud_byoc_i_project_settings.this.private_link_enabled
 
+  is_existing_network = var.existing_network != null
+  is_existing_gke     = var.existing_gke != null
+
+  network_project_id = local.is_existing_network ? var.existing_network.network_project_id : var.gcp_project_id
+
   vpc_name         = var.customer_vpc_name != "" ? var.customer_vpc_name : "${local.prefix_name}-vpc"
-  gke_cluster_name = var.customer_gke_cluster_name != "" ? var.customer_gke_cluster_name : "${local.prefix_name}-gke"
+  gke_cluster_name = local.is_existing_gke ? var.existing_gke.cluster_name : (var.customer_gke_cluster_name != "" ? var.customer_gke_cluster_name : "${local.prefix_name}-gke")
   booter_vm_name   = "${local.prefix_name}-booter"
   bucket_name_raw  = var.customer_bucket_name != "" ? var.customer_bucket_name : "${local.prefix_name}-bucket"
   bucket_name      = substr(lower(replace(local.bucket_name_raw, "_", "-")), 0, min(length(local.bucket_name_raw), 63))
@@ -33,6 +38,78 @@ locals {
         disk_size = max(ng.disk_size, 100)
     })
   }
+
+  required_node_pool_names = toset([
+    for name, group in local.k8s_node_groups : name
+    if group.max_size > 0 && contains(keys(local.required_node_pool_labels), name)
+  ])
+
+  required_node_pool_labels = {
+    core = {
+      "zilliz-group-name"     = "core"
+      "node-role/etcd"        = "true"
+      "node-role/pulsar"      = "true"
+      "node-role/infra"       = "true"
+      "node-role/vdc"         = "true"
+      "node-role/milvus-tool" = "true"
+      "capacity-type"         = "ON_DEMAND"
+    }
+    search = {
+      "zilliz-group-name"    = "search"
+      "node-role/diskANN"    = "true"
+      "node-role/milvus"     = "true"
+      "node-role/nvme-quota" = "200"
+    }
+    index = {
+      "zilliz-group-name"    = "index"
+      "node-role/index-pool" = "true"
+    }
+    fundamental = {
+      "zilliz-group-name" = "fundamental"
+      "node-role/default" = "true"
+      "node-role/milvus"  = "true"
+    }
+    tiered = {
+      "zilliz-group-name" = "tiered"
+      "node-role/tiered"  = "true"
+      "node-role/milvus"  = "true"
+    }
+  }
+
+  existing_primary_secondary_ranges = local.is_existing_network ? {
+    for secondary_range in data.google_compute_subnetwork.existing_primary[0].secondary_ip_range :
+    secondary_range.range_name => secondary_range.ip_cidr_range
+  } : {}
+
+  existing_node_pools = local.is_existing_gke ? {
+    for node_pool in data.google_container_cluster.existing[0].node_pool :
+    node_pool.name => node_pool
+  } : {}
+
+  resolved_vpc_name = local.is_existing_network ? data.google_compute_network.existing[0].name : module.vpc[0].vpc_name
+  network_self_link = local.is_existing_network ? data.google_compute_network.existing[0].self_link : module.vpc[0].vpc_self_link
+
+  primary_subnet_name      = local.is_existing_network ? data.google_compute_subnetwork.existing_primary[0].name : module.vpc[0].primary_subnet_name
+  primary_subnet_self_link = local.is_existing_network ? data.google_compute_subnetwork.existing_primary[0].self_link : module.vpc[0].primary_subnet_self_link
+  primary_subnet_cidr      = local.is_existing_network ? data.google_compute_subnetwork.existing_primary[0].ip_cidr_range : module.vpc[0].primary_subnet_cidr
+
+  pod_subnet_name     = local.is_existing_network ? var.existing_network.pod_secondary_range_name : module.vpc[0].pod_subnet_name
+  pod_subnet_cidr     = local.is_existing_network ? lookup(local.existing_primary_secondary_ranges, var.existing_network.pod_secondary_range_name, null) : module.vpc[0].pod_subnet_cidr
+  service_subnet_name = local.is_existing_network ? var.existing_network.service_secondary_range_name : module.vpc[0].service_subnet_name
+  service_subnet_cidr = local.is_existing_network ? lookup(local.existing_primary_secondary_ranges, var.existing_network.service_secondary_range_name, null) : module.vpc[0].service_subnet_cidr
+
+  lb_subnet_name = local.is_existing_network ? data.google_compute_subnetwork.existing_lb[0].name : module.vpc[0].lb_subnet_name
+  lb_subnet_cidr = local.is_existing_network ? data.google_compute_subnetwork.existing_lb[0].ip_cidr_range : module.vpc[0].lb_subnet_cidr
+
+  gcp_zones = local.is_existing_gke ? sort(tolist(data.google_container_cluster.existing[0].node_locations)) : local.default_gcp_zones
+  booter_zone = try(
+    local.gcp_zones[0],
+    local.default_gcp_zones[0],
+  )
+  master_ipv4_cidr_block = local.is_existing_gke ? try(
+    data.google_container_cluster.existing[0].private_cluster_config[0].master_ipv4_cidr_block,
+    null,
+  ) : var.master_ipv4_cidr_block
 
   dataplane_suffix               = regex("[^-]+$", local.data_plane_id)
   env_domain                     = var.env == "UAT" ? "cloud-uat3.zilliz.com" : "cloud.zilliz.com"
@@ -54,7 +131,7 @@ locals {
     "cloud-tunnel.${local.gcp_private_service_domain}.",
     "cloud-open-api.${local.gcp_private_service_domain}.",
   ]
-  agent_image_url   = data.zillizcloud_byoc_i_project_settings.this.op_config.agent_image_url
+  agent_image_url = data.zillizcloud_byoc_i_project_settings.this.op_config.agent_image_url
   agent_image_tag = (
     can(regex("/", local.agent_image_url)) && can(regex(":", local.agent_image_url))
     ? element(split(":", local.agent_image_url), length(split(":", local.agent_image_url)) - 1)
@@ -147,6 +224,6 @@ locals {
 
   ext_config = {
     gcp_project_id   = var.gcp_project_id
-    gke_cluster_name = module.gke.cluster_name
+    gke_cluster_name = local.gke_cluster_name
   }
 }

--- a/examples/gcp-project-byoc-I/main.tf
+++ b/examples/gcp-project-byoc-I/main.tf
@@ -4,6 +4,7 @@ data "zillizcloud_byoc_i_project_settings" "this" {
 }
 
 module "vpc" {
+  count  = local.is_existing_network ? 0 : 1
   source = "../../modules/gcp_byoc_i/vpc"
 
   prefix_name    = local.prefix_name
@@ -37,37 +38,39 @@ module "gcs" {
 module "iam" {
   source = "../../modules/gcp_byoc_i/iam"
 
-  gcp_project_id                    = var.gcp_project_id
-  prefix_name                       = local.prefix_name
-  gke_location                      = local.gcp_region
-  gke_cluster_name                  = local.gke_cluster_name
-  storage_bucket_name               = module.gcs.bucket_id
-  gke_node_service_account_name     = var.customer_gke_node_service_account_name
-  management_service_account_name   = var.customer_management_service_account_name
-  storage_service_account_name      = var.customer_storage_service_account_name
-  booter_service_account_name       = var.customer_booter_service_account_name
-  storage_workload_identity_ksas    = local.storage_workload_identity_ksas
-  enable_direct_mig_resize          = var.enable_direct_mig_resize
-  booter_instance_name              = local.booter_vm_name
-  booter_zone                       = local.gcp_zones[0]
-  enable_resource_manager_tags      = var.enable_resource_manager_tags
-  vendor_tag_key_id                 = local.vendor_tag_key_id
-  vendor_tag_value_id               = local.vendor_tag_value_id
+  gcp_project_id                  = var.gcp_project_id
+  prefix_name                     = local.prefix_name
+  gke_location                    = local.gcp_region
+  gke_cluster_name                = local.gke_cluster_name
+  storage_bucket_name             = module.gcs.bucket_id
+  gke_node_service_account_name   = var.customer_gke_node_service_account_name
+  existing_gke_node_sa_email      = local.is_existing_gke ? var.existing_gke.node_service_account_email : ""
+  management_service_account_name = var.customer_management_service_account_name
+  storage_service_account_name    = var.customer_storage_service_account_name
+  booter_service_account_name     = var.customer_booter_service_account_name
+  storage_workload_identity_ksas  = local.storage_workload_identity_ksas
+  enable_direct_mig_resize        = var.enable_direct_mig_resize
+  booter_instance_name            = local.booter_vm_name
+  booter_zone                     = local.booter_zone
+  enable_resource_manager_tags    = var.enable_resource_manager_tags
+  vendor_tag_key_id               = local.vendor_tag_key_id
+  vendor_tag_value_id             = local.vendor_tag_value_id
 
   depends_on = [google_project_service.required, terraform_data.vendor_tag_input_validation]
 }
 
 module "gke" {
+  count  = local.is_existing_gke ? 0 : 1
   source = "../../modules/gcp_byoc_i/gke"
 
   gcp_project_id           = var.gcp_project_id
   gcp_region               = local.gcp_region
-  gcp_zones                = local.gcp_zones
+  gcp_zones                = local.default_gcp_zones
   cluster_name             = local.gke_cluster_name
-  network_self_link        = module.vpc.vpc_self_link
-  primary_subnet_self_link = module.vpc.primary_subnet_self_link
-  pod_subnet_name          = module.vpc.pod_subnet_name
-  service_subnet_name      = module.vpc.service_subnet_name
+  network_self_link        = local.network_self_link
+  primary_subnet_self_link = local.primary_subnet_self_link
+  pod_subnet_name          = local.pod_subnet_name
+  service_subnet_name      = local.service_subnet_name
   gke_node_sa_email        = module.iam.gke_node_sa_email
   k8s_node_groups          = local.k8s_node_groups
   kubernetes_version       = var.kubernetes_version
@@ -75,7 +78,7 @@ module "gke" {
   labels                   = local.common_labels
   master_authorized_networks = [
     {
-      cidr_block   = module.vpc.primary_subnet_cidr
+      cidr_block   = local.primary_subnet_cidr
       display_name = "byoc-primary-subnet"
     }
   ]
@@ -87,13 +90,15 @@ module "private_link" {
   count  = local.enable_private_link ? 1 : 0
   source = "../../modules/gcp_byoc_i/private-link"
 
-  prefix_name           = local.prefix_name
-  gcp_region            = local.gcp_region
-  vpc_name              = module.vpc.vpc_name
-  subnet_name           = module.vpc.primary_subnet_name
-  service_attachment_id = local.gcp_psc_service_attachment_id
-  enable_private_dns    = var.enable_private_dns
-  private_dns_domain    = local.psc_private_dns_domain
+  prefix_name              = local.prefix_name
+  gcp_project_id           = var.gcp_project_id
+  network_project_id       = local.network_project_id
+  gcp_region               = local.gcp_region
+  vpc_name                 = local.resolved_vpc_name
+  subnet_name              = local.primary_subnet_name
+  service_attachment_id    = local.gcp_psc_service_attachment_id
+  enable_private_dns       = var.enable_private_dns
+  private_dns_domain       = local.psc_private_dns_domain
   private_dns_record_names = local.psc_private_dns_record_names
 
   depends_on = [google_project_service.required, module.vpc]
@@ -103,22 +108,22 @@ module "booter_vm" {
   count  = data.zillizcloud_byoc_i_project_settings.this.agent_bootstrap_required ? 1 : 0
   source = "../../modules/gcp_byoc_i/booter-vm"
 
-  prefix_name                  = local.prefix_name
-  instance_name                = local.booter_vm_name
-  gcp_project_id               = var.gcp_project_id
-  gcp_region                   = local.gcp_region
-  gcp_zone                     = local.gcp_zones[0]
-  subnet_self_link             = module.vpc.primary_subnet_self_link
-  booter_service_account_email = module.iam.booter_sa_email
-  booter_image                 = local.booter_image
-  machine_type                 = var.booter_machine_type
+  prefix_name                     = local.prefix_name
+  instance_name                   = local.booter_vm_name
+  gcp_project_id                  = var.gcp_project_id
+  gcp_region                      = local.gcp_region
+  gcp_zone                        = local.booter_zone
+  subnet_self_link                = local.primary_subnet_self_link
+  booter_service_account_email    = module.iam.booter_sa_email
+  booter_image                    = local.booter_image
+  machine_type                    = var.booter_machine_type
   failure_self_delete_ttl_seconds = var.booter_failure_self_delete_ttl_seconds
   print_serial_logs_on_apply      = var.booter_print_serial_logs_on_apply
-  gke_cluster_name             = module.gke.cluster_name
-  dataplane_id                 = local.data_plane_id
-  agent_config                 = local.agent_config
-  labels                       = local.common_labels
-  resource_manager_tags        = local.vendor_resource_manager_tags
+  gke_cluster_name                = local.gke_cluster_name
+  dataplane_id                    = local.data_plane_id
+  agent_config                    = local.agent_config
+  labels                          = local.common_labels
+  resource_manager_tags           = local.vendor_resource_manager_tags
 
   depends_on = [google_project_service.required, terraform_data.vendor_tag_input_validation, module.iam, module.gke, module.private_link]
 }
@@ -139,11 +144,11 @@ resource "zillizcloud_byoc_i_project" "this" {
     project_id = var.gcp_project_id
 
     network = {
-      vpc_name            = module.vpc.vpc_name
-      primary_subnet_name = module.vpc.primary_subnet_name
-      pod_subnet_name     = module.vpc.pod_subnet_name
-      service_subnet_name = module.vpc.service_subnet_name
-      lb_subnet_name      = module.vpc.lb_subnet_name
+      vpc_name            = local.resolved_vpc_name
+      primary_subnet_name = local.primary_subnet_name
+      pod_subnet_name     = local.pod_subnet_name
+      service_subnet_name = local.service_subnet_name
+      lb_subnet_name      = local.lb_subnet_name
       psc_endpoint_ip     = local.psc_endpoint_ip
     }
 
@@ -154,7 +159,7 @@ resource "zillizcloud_byoc_i_project" "this" {
     }
 
     gke = {
-      cluster_name = module.gke.cluster_name
+      cluster_name = local.gke_cluster_name
       zones        = local.gcp_zones
     }
 
@@ -172,10 +177,21 @@ resource "zillizcloud_byoc_i_project" "this" {
     module.iam,
     module.private_link,
     module.booter_vm,
+    terraform_data.existing_infrastructure_validation,
   ]
 
   lifecycle {
     ignore_changes  = [data_plane_id, project_id, gcp, ext_config]
     prevent_destroy = true
   }
+}
+
+moved {
+  from = module.vpc
+  to   = module.vpc[0]
+}
+
+moved {
+  from = module.gke
+  to   = module.gke[0]
 }

--- a/examples/gcp-project-byoc-I/outputs.tf
+++ b/examples/gcp-project-byoc-I/outputs.tf
@@ -7,7 +7,7 @@ output "data_plane_id" {
 }
 
 output "gke_cluster_name" {
-  value = module.gke.cluster_name
+  value = local.gke_cluster_name
 }
 
 output "gcs_bucket_id" {
@@ -39,27 +39,27 @@ output "booter_vm_name" {
 }
 
 output "vpc_cidr" {
-  value = var.vpc_cidr
+  value = local.is_existing_network ? null : var.vpc_cidr
 }
 
 output "primary_subnet_cidr" {
-  value = module.vpc.primary_subnet_cidr
+  value = local.primary_subnet_cidr
 }
 
 output "pod_subnet_cidr" {
-  value = module.vpc.pod_subnet_cidr
+  value = local.pod_subnet_cidr
 }
 
 output "service_subnet_cidr" {
-  value = module.vpc.service_subnet_cidr
+  value = local.service_subnet_cidr
 }
 
 output "lb_subnet_cidr" {
-  value = module.vpc.lb_subnet_cidr
+  value = local.lb_subnet_cidr
 }
 
 output "master_ipv4_cidr_block" {
-  value = var.master_ipv4_cidr_block
+  value = local.master_ipv4_cidr_block
 }
 
 output "psc_endpoint_ip" {

--- a/examples/gcp-project-byoc-I/terraform.sample.tfvars
+++ b/examples/gcp-project-byoc-I/terraform.sample.tfvars
@@ -2,6 +2,22 @@ project_id     = "proj-xxxxxxxx"
 dataplane_id   = "zilliz-byoc-gcp-us-west1-xxxxxxxx"
 gcp_project_id = "customer-gcp-project"
 
+# Reuse an existing Shared VPC and an existing regional GKE cluster.
+# The VPC/subnets live in the host project; the GKE cluster lives in gcp_project_id.
+# Existing resources are read-only and are never added to this Terraform state.
+# existing_network = {
+#   network_project_id           = "customer-network-host-project"
+#   vpc_name                     = "shared-vpc"
+#   primary_subnet_name          = "shared-vpc-us-west1-primary"
+#   pod_secondary_range_name     = "shared-vpc-us-west1-pods"
+#   service_secondary_range_name = "shared-vpc-us-west1-services"
+#   lb_subnet_name               = "shared-vpc-us-west1-proxy-only"
+# }
+# existing_gke = {
+#   cluster_name               = "customer-gke"
+#   node_service_account_email = "gke-node@customer-gcp-project.iam.gserviceaccount.com"
+# }
+
 # Optional overrides.
 # vpc_cidr = "10.0.0.0/16"
 # Use a unique /28 when peering multiple BYOC-I VPCs.

--- a/examples/gcp-project-byoc-I/tests/default.tftest.hcl
+++ b/examples/gcp-project-byoc-I/tests/default.tftest.hcl
@@ -1,0 +1,258 @@
+mock_provider "google" {}
+mock_provider "zillizcloud" {}
+
+override_data {
+  target = data.zillizcloud_byoc_i_project_settings.this
+  values = {
+    id                       = "settings-id"
+    project_id               = "zilliz-project"
+    project_name             = "test-project"
+    data_plane_id            = "zilliz-byoc-gcp-us-west1-123456789012"
+    cloud_provider           = "gcp"
+    region                   = "gcp-us-west1"
+    private_link_enabled     = false
+    agent_bootstrap_required = false
+    tiered_node_quota = {
+      disk_size      = 100
+      min_size       = 0
+      max_size       = 0
+      desired_size   = 0
+      instance_types = "n2-standard-8"
+      capacity_type  = "ON_DEMAND"
+    }
+    node_quotas = {
+      core = {
+        disk_size      = 100
+        min_size       = 1
+        max_size       = 3
+        desired_size   = 1
+        instance_types = "n2-standard-8"
+        capacity_type  = "ON_DEMAND"
+      }
+      fundamental = {
+        disk_size      = 100
+        min_size       = 1
+        max_size       = 3
+        desired_size   = 1
+        instance_types = "n2-standard-8"
+        capacity_type  = "ON_DEMAND"
+      }
+      index = {
+        disk_size      = 100
+        min_size       = 1
+        max_size       = 3
+        desired_size   = 1
+        instance_types = "n2-standard-8"
+        capacity_type  = "ON_DEMAND"
+      }
+      search = {
+        disk_size      = 100
+        min_size       = 1
+        max_size       = 3
+        desired_size   = 1
+        instance_types = "n2-standard-8"
+        capacity_type  = "ON_DEMAND"
+      }
+    }
+    op_config = {
+      token           = "test-token"
+      agent_image_url = "test-tag"
+    }
+  }
+}
+
+run "creates_network_and_gke_by_default" {
+  command = plan
+
+  variables {
+    project_id                   = "zilliz-project"
+    dataplane_id                 = "zilliz-byoc-gcp-us-west1-123456789012"
+    gcp_project_id               = "customer-service-project"
+    enable_private_link          = false
+    enable_resource_manager_tags = false
+  }
+
+  assert {
+    condition     = length(module.vpc) == 1
+    error_message = "The default path must continue creating the VPC module."
+  }
+
+  assert {
+    condition     = length(module.gke) == 1
+    error_message = "The default path must continue creating the GKE module."
+  }
+}
+
+run "rejects_existing_gke_without_existing_network" {
+  command = plan
+
+  variables {
+    project_id                   = "zilliz-project"
+    dataplane_id                 = "zilliz-byoc-gcp-us-west1-123456789012"
+    gcp_project_id               = "customer-service-project"
+    enable_private_link          = false
+    enable_resource_manager_tags = false
+    existing_gke = {
+      cluster_name               = "customer-gke"
+      node_service_account_email = "gke-node@customer-service-project.iam.gserviceaccount.com"
+    }
+  }
+
+  expect_failures = [terraform_data.existing_infrastructure_validation]
+}
+
+run "reuses_existing_shared_vpc_and_gke" {
+  command = plan
+
+  variables {
+    project_id                   = "zilliz-project"
+    dataplane_id                 = "zilliz-byoc-gcp-us-west1-123456789012"
+    gcp_project_id               = "customer-service-project"
+    enable_private_link          = false
+    enable_resource_manager_tags = false
+    existing_network = {
+      network_project_id           = "customer-network-host-project"
+      vpc_name                     = "shared-vpc"
+      primary_subnet_name          = "primary"
+      pod_secondary_range_name     = "pods"
+      service_secondary_range_name = "services"
+      lb_subnet_name               = "proxy-only"
+    }
+    existing_gke = {
+      cluster_name               = "customer-gke"
+      node_service_account_email = "gke-node@customer-service-project.iam.gserviceaccount.com"
+    }
+  }
+
+  override_data {
+    target = data.google_compute_network.existing[0]
+    values = {
+      name      = "shared-vpc"
+      self_link = "projects/customer-network-host-project/global/networks/shared-vpc"
+    }
+  }
+
+  override_data {
+    target = data.google_compute_subnetwork.existing_primary[0]
+    values = {
+      name          = "primary"
+      network       = "projects/customer-network-host-project/global/networks/shared-vpc"
+      self_link     = "projects/customer-network-host-project/regions/us-west1/subnetworks/primary"
+      ip_cidr_range = "10.0.0.0/20"
+      secondary_ip_range = [
+        {
+          range_name    = "pods"
+          ip_cidr_range = "10.16.0.0/14"
+        },
+        {
+          range_name    = "services"
+          ip_cidr_range = "10.20.0.0/20"
+        },
+      ]
+    }
+  }
+
+  override_data {
+    target = data.google_compute_subnetwork.existing_lb[0]
+    values = {
+      name          = "proxy-only"
+      network       = "projects/customer-network-host-project/global/networks/shared-vpc"
+      self_link     = "projects/customer-network-host-project/regions/us-west1/subnetworks/proxy-only"
+      ip_cidr_range = "10.21.0.0/23"
+    }
+  }
+
+  override_data {
+    target = data.google_container_cluster.existing[0]
+    values = {
+      name            = "customer-gke"
+      location        = "us-west1"
+      network         = "projects/customer-network-host-project/global/networks/shared-vpc"
+      subnetwork      = "projects/customer-network-host-project/regions/us-west1/subnetworks/primary"
+      networking_mode = "VPC_NATIVE"
+      node_locations  = ["us-west1-a", "us-west1-b", "us-west1-c"]
+      private_cluster_config = [{
+        enable_private_nodes    = true
+        enable_private_endpoint = true
+        master_ipv4_cidr_block  = "172.16.0.0/28"
+      }]
+      workload_identity_config = [{
+        workload_pool = "customer-service-project.svc.id.goog"
+      }]
+      ip_allocation_policy = [{
+        cluster_secondary_range_name  = "pods"
+        services_secondary_range_name = "services"
+      }]
+      node_pool = [
+        {
+          name = "core"
+          node_config = [{
+            service_account = "gke-node@customer-service-project.iam.gserviceaccount.com"
+            labels = {
+              "zilliz-group-name"     = "core"
+              "node-role/etcd"        = "true"
+              "node-role/pulsar"      = "true"
+              "node-role/infra"       = "true"
+              "node-role/vdc"         = "true"
+              "node-role/milvus-tool" = "true"
+              "capacity-type"         = "ON_DEMAND"
+            }
+          }]
+        },
+        {
+          name = "fundamental"
+          node_config = [{
+            service_account = "gke-node@customer-service-project.iam.gserviceaccount.com"
+            labels = {
+              "zilliz-group-name" = "fundamental"
+              "node-role/default" = "true"
+              "node-role/milvus"  = "true"
+            }
+          }]
+        },
+        {
+          name = "index"
+          node_config = [{
+            service_account = "gke-node@customer-service-project.iam.gserviceaccount.com"
+            labels = {
+              "zilliz-group-name"    = "index"
+              "node-role/index-pool" = "true"
+            }
+          }]
+        },
+        {
+          name = "search"
+          node_config = [{
+            service_account = "gke-node@customer-service-project.iam.gserviceaccount.com"
+            labels = {
+              "zilliz-group-name"    = "search"
+              "node-role/diskANN"    = "true"
+              "node-role/milvus"     = "true"
+              "node-role/nvme-quota" = "200"
+            }
+          }]
+        },
+      ]
+    }
+  }
+
+  assert {
+    condition     = length(module.vpc) == 0
+    error_message = "The existing Shared VPC path must not create the VPC module."
+  }
+
+  assert {
+    condition     = length(module.gke) == 0
+    error_message = "The existing GKE path must not create the GKE module."
+  }
+
+  assert {
+    condition     = output.gke_cluster_name == "customer-gke"
+    error_message = "The existing GKE cluster name must flow to the BYOC-I configuration."
+  }
+
+  assert {
+    condition     = module.iam.gke_node_sa_email == "gke-node@customer-service-project.iam.gserviceaccount.com"
+    error_message = "The existing GKE node service account must be reused by the IAM module."
+  }
+}

--- a/examples/gcp-project-byoc-I/variables.tf
+++ b/examples/gcp-project-byoc-I/variables.tf
@@ -16,6 +16,45 @@ variable "gcp_project_id" {
   nullable    = false
 }
 
+variable "existing_network" {
+  description = "Optional existing Shared VPC network configuration. The network and subnets are read-only and are not managed by this Terraform configuration."
+  type = object({
+    network_project_id           = string
+    vpc_name                     = string
+    primary_subnet_name          = string
+    pod_secondary_range_name     = string
+    service_secondary_range_name = string
+    lb_subnet_name               = string
+  })
+  default  = null
+  nullable = true
+
+  validation {
+    condition = var.existing_network == null ? true : alltrue([
+      for value in values(var.existing_network) : trimspace(value) != ""
+    ])
+    error_message = "All existing_network fields must be non-empty when existing_network is set."
+  }
+}
+
+variable "existing_gke" {
+  description = "Optional existing regional GKE cluster configuration. The cluster and its node pools are read-only and are not managed by this Terraform configuration."
+  type = object({
+    cluster_name               = string
+    node_service_account_email = string
+  })
+  default  = null
+  nullable = true
+
+  validation {
+    condition = var.existing_gke == null ? true : (
+      trimspace(var.existing_gke.cluster_name) != "" &&
+      can(regex("^[^@\\s]+@[^@\\s]+\\.iam\\.gserviceaccount\\.com$", var.existing_gke.node_service_account_email))
+    )
+    error_message = "existing_gke requires a non-empty cluster_name and a valid GCP service account email."
+  }
+}
+
 variable "image_repo_url" {
   description = "Optional image repository base URL for BYOC-I booter and cloud-agent images, without image name or tag. For example: us-docker.pkg.dev/<project>/<repository>."
   type        = string

--- a/modules/gcp_byoc_i/iam/iam.tf
+++ b/modules/gcp_byoc_i/iam/iam.tf
@@ -1,7 +1,7 @@
 resource "google_project_iam_member" "gke_node_default" {
   project = var.gcp_project_id
   role    = "roles/container.defaultNodeServiceAccount"
-  member  = "serviceAccount:${google_service_account.gke_node.email}"
+  member  = "serviceAccount:${local.gke_node_sa_email}"
 
   condition {
     title       = "zilliz_byoc_i_target_cluster_node_sa"
@@ -13,13 +13,13 @@ resource "google_project_iam_member" "gke_node_default" {
 resource "google_project_iam_member" "gke_node_logging" {
   project = var.gcp_project_id
   role    = "roles/logging.logWriter"
-  member  = "serviceAccount:${google_service_account.gke_node.email}"
+  member  = "serviceAccount:${local.gke_node_sa_email}"
 }
 
 resource "google_project_iam_member" "gke_node_monitoring" {
   project = var.gcp_project_id
   role    = "roles/monitoring.metricWriter"
-  member  = "serviceAccount:${google_service_account.gke_node.email}"
+  member  = "serviceAccount:${local.gke_node_sa_email}"
 }
 
 resource "google_project_iam_custom_role" "maintenance_cluster" {
@@ -157,7 +157,7 @@ resource "google_project_iam_member" "maintenance_project_reader" {
 }
 
 resource "google_service_account_iam_member" "management_can_use_node_sa" {
-  service_account_id = google_service_account.gke_node.name
+  service_account_id = local.gke_node_sa_resource_name
   role               = "roles/iam.serviceAccountUser"
   member             = "serviceAccount:${google_service_account.management.email}"
 }

--- a/modules/gcp_byoc_i/iam/locals.tf
+++ b/modules/gcp_byoc_i/iam/locals.tf
@@ -1,11 +1,15 @@
 locals {
-  sa_prefix          = trimsuffix(substr(var.prefix_name, 0, 18), "-")
-  gke_node_sa_name   = var.gke_node_service_account_name != "" ? var.gke_node_service_account_name : "${local.sa_prefix}-node"
-  management_sa_name = var.management_service_account_name != "" ? var.management_service_account_name : "${local.sa_prefix}-maintenance"
-  storage_sa_name    = var.storage_service_account_name != "" ? var.storage_service_account_name : "${local.sa_prefix}-storage"
-  booter_sa_name     = var.booter_service_account_name != "" ? var.booter_service_account_name : "${local.sa_prefix}-booter"
-  role_suffix_raw    = replace(title(replace(var.prefix_name, "-", " ")), " ", "")
-  role_suffix        = substr(local.role_suffix_raw, 0, 20)
+  sa_prefix                 = trimsuffix(substr(var.prefix_name, 0, 18), "-")
+  use_existing_gke_node_sa  = var.existing_gke_node_sa_email != ""
+  gke_node_sa_account_id    = local.use_existing_gke_node_sa ? split("@", var.existing_gke_node_sa_email)[0] : (var.gke_node_service_account_name != "" ? var.gke_node_service_account_name : "${local.sa_prefix}-node")
+  gke_node_sa_project_id    = local.use_existing_gke_node_sa ? trimsuffix(split("@", var.existing_gke_node_sa_email)[1], ".iam.gserviceaccount.com") : var.gcp_project_id
+  gke_node_sa_email         = local.use_existing_gke_node_sa ? var.existing_gke_node_sa_email : google_service_account.gke_node[0].email
+  gke_node_sa_resource_name = local.use_existing_gke_node_sa ? "projects/${local.gke_node_sa_project_id}/serviceAccounts/${local.gke_node_sa_email}" : google_service_account.gke_node[0].name
+  management_sa_name        = var.management_service_account_name != "" ? var.management_service_account_name : "${local.sa_prefix}-maintenance"
+  storage_sa_name           = var.storage_service_account_name != "" ? var.storage_service_account_name : "${local.sa_prefix}-storage"
+  booter_sa_name            = var.booter_service_account_name != "" ? var.booter_service_account_name : "${local.sa_prefix}-booter"
+  role_suffix_raw           = replace(title(replace(var.prefix_name, "-", " ")), " ", "")
+  role_suffix               = substr(local.role_suffix_raw, 0, 20)
 
   storage_cluster_workload_identity_member = "principalSet://iam.googleapis.com/projects/${data.google_project.this.number}/locations/global/workloadIdentityPools/${var.gcp_project_id}.svc.id.goog/kubernetes.cluster/https://container.googleapis.com/v1/projects/${var.gcp_project_id}/locations/${var.gke_location}/clusters/${var.gke_cluster_name}"
 

--- a/modules/gcp_byoc_i/iam/outputs.tf
+++ b/modules/gcp_byoc_i/iam/outputs.tf
@@ -1,5 +1,5 @@
 output "gke_node_sa_email" {
-  value = google_service_account.gke_node.email
+  value = local.gke_node_sa_email
 }
 
 output "management_sa_email" {

--- a/modules/gcp_byoc_i/iam/service_accounts.tf
+++ b/modules/gcp_byoc_i/iam/service_accounts.tf
@@ -1,6 +1,6 @@
 resource "terraform_data" "service_account_name_validation" {
   input = {
-    gke_node_sa_name   = local.gke_node_sa_name
+    gke_node_sa_name   = local.gke_node_sa_account_id
     management_sa_name = local.management_sa_name
     storage_sa_name    = local.storage_sa_name
     booter_sa_name     = local.booter_sa_name
@@ -9,7 +9,7 @@ resource "terraform_data" "service_account_name_validation" {
   lifecycle {
     precondition {
       condition = length(distinct([
-        local.gke_node_sa_name,
+        local.gke_node_sa_account_id,
         local.management_sa_name,
         local.storage_sa_name,
         local.booter_sa_name,
@@ -20,11 +20,18 @@ resource "terraform_data" "service_account_name_validation" {
 }
 
 resource "google_service_account" "gke_node" {
+  count = local.use_existing_gke_node_sa ? 0 : 1
+
   project      = var.gcp_project_id
-  account_id   = local.gke_node_sa_name
+  account_id   = local.gke_node_sa_account_id
   display_name = "Zilliz BYOC-I GKE node service account"
 
   depends_on = [terraform_data.service_account_name_validation]
+}
+
+moved {
+  from = google_service_account.gke_node
+  to   = google_service_account.gke_node[0]
 }
 
 resource "google_service_account" "management" {

--- a/modules/gcp_byoc_i/iam/variables.tf
+++ b/modules/gcp_byoc_i/iam/variables.tf
@@ -29,6 +29,20 @@ variable "gke_node_service_account_name" {
   default     = ""
 }
 
+variable "existing_gke_node_sa_email" {
+  description = "Optional existing GKE node service account email. When set, Terraform reuses the account and only manages the required IAM grants."
+  type        = string
+  default     = ""
+
+  validation {
+    condition = var.existing_gke_node_sa_email == "" || can(regex(
+      "^[^@\\s]+@[^@\\s]+\\.iam\\.gserviceaccount\\.com$",
+      var.existing_gke_node_sa_email,
+    ))
+    error_message = "existing_gke_node_sa_email must be empty or a valid GCP service account email."
+  }
+}
+
 variable "management_service_account_name" {
   description = "Maintenance service account account_id. Defaults to <prefix_name>-maintenance."
   type        = string

--- a/modules/gcp_byoc_i/private-link/main.tf
+++ b/modules/gcp_byoc_i/private-link/main.tf
@@ -1,13 +1,16 @@
 data "google_compute_network" "this" {
-  name = var.vpc_name
+  project = var.network_project_id
+  name    = var.vpc_name
 }
 
 data "google_compute_subnetwork" "this" {
-  name   = var.subnet_name
-  region = var.gcp_region
+  project = var.network_project_id
+  name    = var.subnet_name
+  region  = var.gcp_region
 }
 
 resource "google_compute_address" "psc" {
+  project      = var.gcp_project_id
   name         = "${var.prefix_name}-psc-ip"
   region       = var.gcp_region
   subnetwork   = data.google_compute_subnetwork.this.id
@@ -15,6 +18,7 @@ resource "google_compute_address" "psc" {
 }
 
 resource "google_compute_forwarding_rule" "byoc_endpoint" {
+  project                 = var.gcp_project_id
   name                    = "${var.prefix_name}-byoc-endpoint"
   region                  = var.gcp_region
   load_balancing_scheme   = ""
@@ -34,6 +38,7 @@ resource "google_compute_forwarding_rule" "byoc_endpoint" {
 resource "google_dns_managed_zone" "psc" {
   count = var.enable_private_dns && local.private_dns_domain != "" ? 1 : 0
 
+  project     = var.network_project_id
   name        = local.private_dns_zone_name
   dns_name    = local.private_dns_domain
   description = "Private DNS zone for Zilliz BYOC Private Service Connect hosts."
@@ -49,6 +54,7 @@ resource "google_dns_managed_zone" "psc" {
 resource "google_dns_record_set" "psc" {
   for_each = var.enable_private_dns && local.private_dns_domain != "" ? toset(var.private_dns_record_names) : toset([])
 
+  project      = var.network_project_id
   name         = endswith(each.value, ".") ? each.value : "${each.value}."
   managed_zone = google_dns_managed_zone.psc[0].name
   type         = "A"

--- a/modules/gcp_byoc_i/private-link/variables.tf
+++ b/modules/gcp_byoc_i/private-link/variables.tf
@@ -3,6 +3,16 @@ variable "prefix_name" {
   type        = string
 }
 
+variable "gcp_project_id" {
+  description = "GCP service project where the PSC endpoint resources are created."
+  type        = string
+}
+
+variable "network_project_id" {
+  description = "GCP project that owns the VPC network and subnetwork. For Shared VPC this is the host project."
+  type        = string
+}
+
 variable "gcp_region" {
   description = "GCP region."
   type        = string


### PR DESCRIPTION
## Summary

- add optional existing_network and existing_gke inputs for GCP BYOC-I
- read and validate customer-owned Shared VPC, subnets, regional private GKE, and required node pools without importing them into state
- reuse the existing GKE node service account while continuing to manage required IAM grants
- create PSC endpoint resources in the service project and bind Shared VPC/DNS resources through the host project
- preserve the default managed VPC/GKE path and add moved blocks for state address compatibility
- document prerequisites, constraints, and managed-to-existing migration risk

## Tests

- terraform test -filter=tests/default.tftest.hcl in examples/gcp-project-byoc-I: 3 passed
- terraform validate in examples/gcp-project-byoc-I
- terraform validate in modules/gcp_byoc_i/iam
- terraform validate in modules/gcp_byoc_i/private-link
- terraform fmt -check -recursive on changed Terraform directories
- git diff --check

## Remaining validation

A live GCP apply was not run. Shared VPC usage still requires the customer to preconfigure host/service project IAM and relevant APIs.