### PR TITLE
feat(gcp-byoc-i): support existing infrastructure and GKE encryption

### DIFF
--- a/examples/gcp-project-byoc-I/README.md
+++ b/examples/gcp-project-byoc-I/README.md
@@ -6,7 +6,7 @@ This example provisions a GCP BYOC-I dataplane with customer-managed infrastruct
 
 - VPC-native GKE networking, Cloud NAT, and firewall rules
 - GCS bucket for dataplane storage
-- GKE private regional cluster and node pools from BYOC-I quota settings
+- GKE private regional cluster and node pools from BYOC-I quota settings, or dedicated BYOC-I node pools in an existing compatible cluster
 - GCP service accounts for GKE nodes, maintenance, storage, and the booter VM
 - Optional Private Service Connect endpoint
 - Short-lived GCE booter VM that uses a dedicated booter service account to install `cloud-agent` into GKE, then self-deletes after a TTL
@@ -52,6 +52,21 @@ Network ownership and resource lifecycle are controlled independently:
 | `manage_shared_vpc_iam` | `true`, `false` | Manage the GKE service-agent grants in the Shared VPC host project |
 
 Terraform never manages the lifecycle of a VPC or subnet selected with an `existing` mode. Destroy only removes resources that this configuration created.
+
+## GKE Cluster Modes
+
+`gke_mode = "create"` is the default and creates both the private regional cluster and its BYOC-I node pools.
+
+To reuse a customer-managed cluster while creating dedicated BYOC-I node pools:
+
+```hcl
+gke_mode                 = "existing"
+customer_gke_cluster_name = "customer-gke"
+```
+
+The existing cluster must be regional in the BYOC-I region, VPC-native, use the selected VPC, primary subnet, Pod range, and Service range, have private nodes enabled, and use the workload identity pool `<gcp_project_id>.svc.id.goog`. If GKE Secrets encryption validation is enabled, `gke_secrets_kms_key_name` must identify the key already configured on the cluster.
+
+In `existing` mode Terraform does not modify or own the cluster. `terraform destroy` preserves it and removes only the BYOC-I node pools and other resources created by this configuration. Reusing existing node pools is not supported.
 
 ### Create a Dedicated VPC and Subnets
 

--- a/examples/gcp-project-byoc-I/README.md
+++ b/examples/gcp-project-byoc-I/README.md
@@ -189,6 +189,42 @@ grant_gcs_kms_key_iam = false
 
 The KMS key location must be compatible with the bucket location. Changing the bucket default KMS key affects new objects written after the change; existing objects are not automatically re-encrypted.
 
+### GKE Application-layer Secrets Encryption
+
+Kubernetes Secrets stored in GKE etcd use Google-managed encryption by default. To add application-layer envelope encryption with a customer-managed Cloud KMS key, enable:
+
+```hcl
+enable_gke_secrets_encryption = true
+```
+
+When `gke_secrets_kms_key_name` is empty, Terraform creates a key ring and crypto key in the GKE region. The generated key names are derived from the GKE cluster name.
+
+To use an existing key instead, provide its full resource name:
+
+```hcl
+gke_secrets_kms_key_name = "projects/<gcp-project-id>/locations/<region>/keyRings/<key-ring>/cryptoKeys/<key>"
+```
+
+The key location must match the GKE region. Terraform grants the Service Project GKE Service Agent:
+
+```text
+service-<SERVICE_PROJECT_NUMBER>@container-engine-robot.iam.gserviceaccount.com
+```
+
+the following role on the exact crypto key:
+
+```text
+roles/cloudkms.cryptoKeyEncrypterDecrypter
+```
+
+If an existing key is managed outside this Terraform configuration and the permission is already present, set:
+
+```hcl
+grant_gke_secrets_kms_key_iam = false
+```
+
+This setting encrypts Kubernetes Secrets stored in GKE etcd. It does not configure node disk CMEK or GCS bucket encryption. Enabling or changing the key on an existing cluster updates the GKE cluster; review the Terraform plan before applying.
+
 The booter image is not required in `terraform.tfvars`. Production defaults to `gcr.io/zilliz-byoc-prod/gcp-byoc-i-booter:latest`; UAT defaults to `gcr.io/zilliz-byoc-uat/gcp-byoc-i-booter:latest`. To use a customer-owned image repository for both the booter and cloud-agent images, set `image_repo_url` to the repository base URL without image name or tag:
 
 ```hcl

--- a/examples/gcp-project-byoc-I/README.md
+++ b/examples/gcp-project-byoc-I/README.md
@@ -37,6 +37,124 @@ The GCP region is read from `zillizcloud_byoc_i_project_settings`. Set `gcp_proj
 
 Default resource names use the prefix `zilliz-dp-<last-12-chars-of-data_plane_id>`. For example, the default VPC, GKE cluster, booter VM, and bucket names are derived from that prefix. If you already deployed this example with older random-suffix names, set the `customer_*` name variables to the existing resource names before applying this version.
 
+## Network Modes
+
+Network ownership and resource lifecycle are controlled independently:
+
+| Variable | Values | Purpose |
+|---|---|---|
+| `network_project_id` | empty or a project ID | Empty uses `gcp_project_id`; a different project selects a Shared VPC host project |
+| `vpc_mode` | `create`, `existing` | Create a dedicated VPC or read an existing VPC |
+| `subnet_mode` | `create`, `existing` | Create the primary GKE subnet and secondary ranges, or read an existing subnet |
+| `lb_subnet_mode` | `create`, `existing` | Create or read the regional managed proxy subnet |
+| `create_cloud_nat` | `true`, `false` | Create dedicated Router/NAT resources, or use existing egress |
+| `create_firewall_rules` | `true`, `false` | Create BYOC-I firewall rules, or let the customer manage them |
+| `manage_shared_vpc_iam` | `true`, `false` | Manage the GKE service-agent grants in the Shared VPC host project |
+
+Terraform never manages the lifecycle of a VPC or subnet selected with an `existing` mode. Destroy only removes resources that this configuration created.
+
+### Create a Dedicated VPC and Subnets
+
+This is the default and is backward compatible:
+
+```hcl
+vpc_mode       = "create"
+subnet_mode    = "create"
+lb_subnet_mode = "create"
+vpc_cidr       = "10.0.0.0/16"
+```
+
+### Existing VPC with New Dedicated Subnets
+
+```hcl
+vpc_mode          = "existing"
+customer_vpc_name = "customer-vpc"
+subnet_mode       = "create"
+lb_subnet_mode    = "create"
+
+primary_subnet = {
+  name = "zilliz-primary"
+  cidr = "10.20.0.0/20"
+}
+pod_subnet = {
+  name = "zilliz-pods"
+  cidr = "10.24.0.0/14"
+}
+service_subnet = {
+  name = "zilliz-services"
+  cidr = "10.28.0.0/20"
+}
+lb_subnet = {
+  name = "zilliz-lb-proxy"
+  cidr = "10.29.0.0/23"
+}
+```
+
+### Existing VPC and Existing Subnets
+
+The existing primary subnet must be in the BYOC-I region and contain the named Pod and Service secondary ranges. The existing LB subnet must have purpose `REGIONAL_MANAGED_PROXY`.
+
+```hcl
+vpc_mode          = "existing"
+customer_vpc_name = "customer-vpc"
+subnet_mode       = "existing"
+lb_subnet_mode    = "existing"
+
+primary_subnet = {
+  name = "customer-gke-subnet"
+}
+pod_subnet = {
+  name = "customer-pods"
+}
+service_subnet = {
+  name = "customer-services"
+}
+lb_subnet = {
+  name = "customer-lb-proxy"
+}
+
+# Disable these when the customer network already supplies egress and firewall policy.
+create_cloud_nat      = false
+create_firewall_rules = false
+```
+
+### Shared VPC
+
+Set `network_project_id` to the Shared VPC host project. The VPC must already exist and the service project must already be attached to the host project. Both new-subnet and existing-subnet modes are supported.
+
+Shared VPC with a new dedicated subnet:
+
+```hcl
+gcp_project_id     = "customer-service-project"
+network_project_id = "customer-host-project"
+
+vpc_mode          = "existing"
+customer_vpc_name = "shared-vpc"
+subnet_mode        = "create"
+lb_subnet_mode     = "create"
+
+primary_subnet = {
+  name = "zilliz-primary"
+  cidr = "10.20.0.0/20"
+}
+pod_subnet = {
+  name = "zilliz-pods"
+  cidr = "10.24.0.0/14"
+}
+service_subnet = {
+  name = "zilliz-services"
+  cidr = "10.28.0.0/20"
+}
+lb_subnet = {
+  name = "zilliz-lb-proxy"
+  cidr = "10.29.0.0/23"
+}
+```
+
+For existing Shared VPC subnets, change both subnet modes to `existing` and provide the existing subnet and secondary-range names as shown in the previous example.
+
+With `manage_shared_vpc_iam = true`, Terraform grants the service project's GKE service agent `roles/container.hostServiceAgentUser` in the host project and grants the GKE and Cloud Services service agents `roles/compute.networkUser` on the primary subnet. Set it to `false` when those grants are centrally managed. The Terraform runner needs permission to read the host VPC and to manage any host-project subnet, NAT, firewall, DNS, or IAM resources enabled by the selected modes.
+
 If multiple GCP BYOC-I VPCs need VPC Peering, configure non-overlapping `vpc_cidr` values and unique GKE private control plane ranges with `master_ipv4_cidr_block`. The default control plane range is `172.16.0.0/28`; a second peered environment can use a different `/28`, such as `172.16.0.16/28`.
 
 The example outputs `primary_subnet_cidr`, `pod_subnet_cidr`, `service_subnet_cidr`, `lb_subnet_cidr`, and `master_ipv4_cidr_block` to make VPC Peering overlap checks and firewall source range setup explicit.

--- a/examples/gcp-project-byoc-I/locals.tf
+++ b/examples/gcp-project-byoc-I/locals.tf
@@ -12,6 +12,9 @@ locals {
 
   enable_private_link = var.enable_private_link && data.zillizcloud_byoc_i_project_settings.this.private_link_enabled
 
+  network_project_id = var.network_project_id != "" ? var.network_project_id : var.gcp_project_id
+  is_shared_vpc      = local.network_project_id != var.gcp_project_id
+
   vpc_name         = var.customer_vpc_name != "" ? var.customer_vpc_name : "${local.prefix_name}-vpc"
   gke_cluster_name = var.customer_gke_cluster_name != "" ? var.customer_gke_cluster_name : "${local.prefix_name}-gke"
   booter_vm_name   = "${local.prefix_name}-booter"
@@ -146,7 +149,12 @@ locals {
   }
 
   ext_config = {
-    gcp_project_id   = var.gcp_project_id
-    gke_cluster_name = module.gke.cluster_name
+    gcp_project_id     = var.gcp_project_id
+    network_project_id = local.network_project_id
+    is_shared_vpc      = local.is_shared_vpc
+    vpc_mode           = var.vpc_mode
+    subnet_mode        = var.subnet_mode
+    lb_subnet_mode     = var.lb_subnet_mode
+    gke_cluster_name   = module.gke.cluster_name
   }
 }

--- a/examples/gcp-project-byoc-I/main.tf
+++ b/examples/gcp-project-byoc-I/main.tf
@@ -68,6 +68,7 @@ module "iam" {
 module "gke" {
   source = "../../modules/gcp_byoc_i/gke"
 
+  gke_mode                 = var.gke_mode
   gcp_project_id           = var.gcp_project_id
   gcp_region               = local.gcp_region
   gcp_zones                = local.gcp_zones
@@ -91,7 +92,7 @@ module "gke" {
     }
   ]
 
-  depends_on = [google_project_service.required, module.iam, module.shared_vpc_iam]
+  depends_on = [google_project_service.required, terraform_data.gke_input_validation, module.iam, module.shared_vpc_iam]
 }
 
 module "shared_vpc_iam" {

--- a/examples/gcp-project-byoc-I/main.tf
+++ b/examples/gcp-project-byoc-I/main.tf
@@ -80,6 +80,9 @@ module "gke" {
   k8s_node_groups          = local.k8s_node_groups
   kubernetes_version       = var.kubernetes_version
   master_ipv4_cidr_block   = var.master_ipv4_cidr_block
+  enable_secrets_encryption = var.enable_gke_secrets_encryption
+  secrets_kms_key_name      = var.gke_secrets_kms_key_name
+  grant_secrets_kms_key_iam = var.grant_gke_secrets_kms_key_iam
   labels                   = local.common_labels
   master_authorized_networks = [
     {

--- a/examples/gcp-project-byoc-I/main.tf
+++ b/examples/gcp-project-byoc-I/main.tf
@@ -16,6 +16,14 @@ module "vpc" {
   lb_subnet      = var.lb_subnet
   labels         = local.common_labels
 
+  gcp_project_id       = var.gcp_project_id
+  network_project_id   = local.network_project_id
+  vpc_mode             = var.vpc_mode
+  subnet_mode          = var.subnet_mode
+  lb_subnet_mode       = var.lb_subnet_mode
+  create_cloud_nat      = var.create_cloud_nat
+  create_firewall_rules = var.create_firewall_rules
+
   depends_on = [google_project_service.required]
 }
 
@@ -80,7 +88,19 @@ module "gke" {
     }
   ]
 
-  depends_on = [google_project_service.required, module.iam]
+  depends_on = [google_project_service.required, module.iam, module.shared_vpc_iam]
+}
+
+module "shared_vpc_iam" {
+  count  = local.is_shared_vpc && var.manage_shared_vpc_iam ? 1 : 0
+  source = "../../modules/gcp_byoc_i/shared-vpc-iam"
+
+  service_project_id  = var.gcp_project_id
+  host_project_id     = local.network_project_id
+  gcp_region          = local.gcp_region
+  primary_subnet_name = module.vpc.primary_subnet_name
+
+  depends_on = [google_project_service.required, module.vpc]
 }
 
 module "private_link" {
@@ -89,12 +109,15 @@ module "private_link" {
 
   prefix_name           = local.prefix_name
   gcp_region            = local.gcp_region
-  vpc_name              = module.vpc.vpc_name
-  subnet_name           = module.vpc.primary_subnet_name
   service_attachment_id = local.gcp_psc_service_attachment_id
   enable_private_dns    = var.enable_private_dns
   private_dns_domain    = local.psc_private_dns_domain
   private_dns_record_names = local.psc_private_dns_record_names
+
+  gcp_project_id     = var.gcp_project_id
+  network_project_id = local.network_project_id
+  vpc_self_link      = module.vpc.vpc_self_link
+  subnet_self_link   = module.vpc.primary_subnet_self_link
 
   depends_on = [google_project_service.required, module.vpc]
 }

--- a/examples/gcp-project-byoc-I/outputs.tf
+++ b/examples/gcp-project-byoc-I/outputs.tf
@@ -42,6 +42,30 @@ output "vpc_cidr" {
   value = var.vpc_cidr
 }
 
+output "network_project_id" {
+  value = local.network_project_id
+}
+
+output "is_shared_vpc" {
+  value = local.is_shared_vpc
+}
+
+output "vpc_name" {
+  value = module.vpc.vpc_name
+}
+
+output "primary_subnet_name" {
+  value = module.vpc.primary_subnet_name
+}
+
+output "lb_subnet_name" {
+  value = module.vpc.lb_subnet_name
+}
+
+output "nat_ip" {
+  value = module.vpc.nat_ip
+}
+
 output "primary_subnet_cidr" {
   value = module.vpc.primary_subnet_cidr
 }

--- a/examples/gcp-project-byoc-I/outputs.tf
+++ b/examples/gcp-project-byoc-I/outputs.tf
@@ -18,6 +18,10 @@ output "gcs_kms_key_name" {
   value = module.gcs.kms_key_name
 }
 
+output "gke_secrets_kms_key_name" {
+  value = module.gke.secrets_kms_key_name
+}
+
 output "management_sa" {
   value = module.iam.management_sa_email
 }

--- a/examples/gcp-project-byoc-I/services.tf
+++ b/examples/gcp-project-byoc-I/services.tf
@@ -7,7 +7,7 @@ locals {
     "dns.googleapis.com",
     "iam.googleapis.com",
     "storage.googleapis.com",
-  ], var.enable_gcs_kms ? ["cloudkms.googleapis.com"] : []))
+  ], var.enable_gcs_kms || var.enable_gke_secrets_encryption ? ["cloudkms.googleapis.com"] : []))
 }
 
 resource "google_project_service" "required" {

--- a/examples/gcp-project-byoc-I/terraform.sample.tfvars
+++ b/examples/gcp-project-byoc-I/terraform.sample.tfvars
@@ -3,6 +3,27 @@ dataplane_id   = "zilliz-byoc-gcp-us-west1-xxxxxxxx"
 gcp_project_id = "customer-gcp-project"
 
 # Optional overrides.
+# Network mode defaults create a dedicated VPC and subnets in gcp_project_id.
+# vpc_mode = "create"
+# subnet_mode = "create"
+# lb_subnet_mode = "create"
+# For an existing VPC, set vpc_mode = "existing" and provide customer_vpc_name.
+# customer_vpc_name = "customer-vpc"
+# For Shared VPC, also set the host project. The service project must already be attached to it.
+# network_project_id = "customer-shared-vpc-host-project"
+# For an existing primary subnet, provide its name and the existing Pod/Service secondary range names:
+# subnet_mode = "existing"
+# primary_subnet = { name = "customer-gke-subnet" }
+# pod_subnet = { name = "customer-pods" }
+# service_subnet = { name = "customer-services" }
+# For an existing regional managed proxy subnet:
+# lb_subnet_mode = "existing"
+# lb_subnet = { name = "customer-lb-proxy" }
+# Disable creation when existing networking already provides these capabilities.
+# create_cloud_nat = false
+# create_firewall_rules = false
+# Set false when Shared VPC IAM grants are centrally managed.
+# manage_shared_vpc_iam = true
 # vpc_cidr = "10.0.0.0/16"
 # Use a unique /28 when peering multiple BYOC-I VPCs.
 # master_ipv4_cidr_block = "172.16.0.0/28"

--- a/examples/gcp-project-byoc-I/terraform.sample.tfvars
+++ b/examples/gcp-project-byoc-I/terraform.sample.tfvars
@@ -47,6 +47,9 @@ gcp_project_id = "customer-gcp-project"
 # booter_print_serial_logs_on_apply = true
 # Default resource names use zilliz-dp-<last-12-chars-of-dataplane_id>. Set these to keep existing names.
 # customer_vpc_name = "zilliz-byoc-vpc"
+# Set to existing to reuse a customer-managed GKE cluster while Terraform creates dedicated BYOC-I node pools.
+# gke_mode = "create"
+# Required when gke_mode = "existing".
 # customer_gke_cluster_name = "zilliz-byoc-gke"
 # customer_bucket_name = "zilliz-byoc-gcp-bucket"
 # bucket_force_destroy = true

--- a/examples/gcp-project-byoc-I/terraform.sample.tfvars
+++ b/examples/gcp-project-byoc-I/terraform.sample.tfvars
@@ -56,6 +56,12 @@ gcp_project_id = "customer-gcp-project"
 # gcs_kms_key_name = "projects/customer-gcp-project/locations/us-west1/keyRings/example-key-ring/cryptoKeys/example-key"
 # For existing keys only, set to false if the Cloud Storage service agent has already been granted KMS encrypter/decrypter permission.
 # grant_gcs_kms_key_iam = true
+# Enable GKE application-layer encryption for Kubernetes Secrets stored in etcd.
+# enable_gke_secrets_encryption = true
+# Optional existing regional KMS key. Leave empty to let Terraform create one in the GKE region.
+# gke_secrets_kms_key_name = "projects/customer-gcp-project/locations/us-west1/keyRings/gke-secrets/cryptoKeys/gke-secrets"
+# Set false if the GKE service agent already has KMS encrypter/decrypter permission on the existing key.
+# grant_gke_secrets_kms_key_iam = true
 # enable_resource_manager_tags = true
 # Leave tag IDs empty to let Terraform create a per-dataplane tag.
 # vendor_tag_key_id = "tagKeys/1234567890"

--- a/examples/gcp-project-byoc-I/validation.tf
+++ b/examples/gcp-project-byoc-I/validation.tf
@@ -1,0 +1,13 @@
+resource "terraform_data" "gke_input_validation" {
+  input = {
+    gke_mode                  = var.gke_mode
+    customer_gke_cluster_name = var.customer_gke_cluster_name
+  }
+
+  lifecycle {
+    precondition {
+      condition     = var.gke_mode != "existing" || var.customer_gke_cluster_name != ""
+      error_message = "customer_gke_cluster_name is required when gke_mode = existing."
+    }
+  }
+}

--- a/examples/gcp-project-byoc-I/variables.tf
+++ b/examples/gcp-project-byoc-I/variables.tf
@@ -316,6 +316,29 @@ variable "grant_gcs_kms_key_iam" {
   default     = true
 }
 
+variable "enable_gke_secrets_encryption" {
+  description = "Enable GKE application-layer encryption for Kubernetes Secrets stored in etcd."
+  type        = bool
+  default     = false
+}
+
+variable "gke_secrets_kms_key_name" {
+  description = "Existing Cloud KMS key for GKE application-layer Secrets encryption. Leave empty to let Terraform create a key in the GKE region."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.gke_secrets_kms_key_name == "" || can(regex("^projects/[^/]+/locations/[^/]+/keyRings/[^/]+/cryptoKeys/[^/]+$", var.gke_secrets_kms_key_name))
+    error_message = "gke_secrets_kms_key_name must be empty or a full Cloud KMS crypto key resource name."
+  }
+}
+
+variable "grant_gke_secrets_kms_key_iam" {
+  description = "Whether Terraform grants the GKE service agent roles/cloudkms.cryptoKeyEncrypterDecrypter on an existing gke_secrets_kms_key_name. Terraform-created keys are always granted."
+  type        = bool
+  default     = true
+}
+
 variable "labels" {
   description = "Labels applied to supported GCP resources."
   type        = map(string)

--- a/examples/gcp-project-byoc-I/variables.tf
+++ b/examples/gcp-project-byoc-I/variables.tf
@@ -104,9 +104,20 @@ variable "manage_shared_vpc_iam" {
 }
 
 variable "customer_gke_cluster_name" {
-  description = "Optional customer GKE cluster name."
+  description = "Optional GKE cluster name override. Required when gke_mode is existing."
   type        = string
   default     = ""
+}
+
+variable "gke_mode" {
+  description = "GKE cluster lifecycle mode. create provisions the cluster and node pools; existing reads an existing cluster and only provisions BYOC-I node pools."
+  type        = string
+  default     = "create"
+
+  validation {
+    condition     = contains(["create", "existing"], var.gke_mode)
+    error_message = "gke_mode must be create or existing."
+  }
 }
 
 variable "customer_bucket_name" {

--- a/examples/gcp-project-byoc-I/variables.tf
+++ b/examples/gcp-project-byoc-I/variables.tf
@@ -40,10 +40,67 @@ variable "vpc_cidr" {
   default     = "10.0.0.0/16"
 }
 
-variable "customer_vpc_name" {
-  description = "Optional customer VPC name."
+variable "network_project_id" {
+  description = "Project that owns the VPC. Defaults to gcp_project_id. Set to a Shared VPC host project ID for Shared VPC mode."
   type        = string
   default     = ""
+}
+
+variable "vpc_mode" {
+  description = "VPC lifecycle mode: create or existing. Shared VPC requires existing."
+  type        = string
+  default     = "create"
+
+  validation {
+    condition     = contains(["create", "existing"], var.vpc_mode)
+    error_message = "vpc_mode must be create or existing."
+  }
+}
+
+variable "subnet_mode" {
+  description = "Primary GKE subnet lifecycle mode: create or existing."
+  type        = string
+  default     = "create"
+
+  validation {
+    condition     = contains(["create", "existing"], var.subnet_mode)
+    error_message = "subnet_mode must be create or existing."
+  }
+}
+
+variable "lb_subnet_mode" {
+  description = "Regional managed proxy subnet lifecycle mode: create or existing."
+  type        = string
+  default     = "create"
+
+  validation {
+    condition     = contains(["create", "existing"], var.lb_subnet_mode)
+    error_message = "lb_subnet_mode must be create or existing."
+  }
+}
+
+variable "customer_vpc_name" {
+  description = "VPC name override. Required when vpc_mode is existing."
+  type        = string
+  default     = ""
+}
+
+variable "create_cloud_nat" {
+  description = "Create a dedicated Cloud Router, external IP, and Cloud NAT for the BYOC-I primary subnet. Disable if existing networking already provides egress."
+  type        = bool
+  default     = true
+}
+
+variable "create_firewall_rules" {
+  description = "Create the BYOC-I health-check and internal firewall rules in the network project."
+  type        = bool
+  default     = true
+}
+
+variable "manage_shared_vpc_iam" {
+  description = "Manage the Shared VPC hostServiceAgentUser and subnet networkUser grants required by GKE. Only used when network_project_id differs from gcp_project_id."
+  type        = bool
+  default     = true
 }
 
 variable "customer_gke_cluster_name" {

--- a/modules/gcp_byoc_i/gke/existing-cluster.tf
+++ b/modules/gcp_byoc_i/gke/existing-cluster.tf
@@ -1,0 +1,7 @@
+data "google_container_cluster" "existing" {
+  count = local.create_cluster ? 0 : 1
+
+  project  = var.gcp_project_id
+  name     = var.cluster_name
+  location = var.gcp_region
+}

--- a/modules/gcp_byoc_i/gke/kms.tf
+++ b/modules/gcp_byoc_i/gke/kms.tf
@@ -1,10 +1,10 @@
 locals {
-  create_secrets_kms_key         = var.enable_secrets_encryption && var.secrets_kms_key_name == ""
-  grant_secrets_kms_key_iam      = var.enable_secrets_encryption && (local.create_secrets_kms_key || var.grant_secrets_kms_key_iam)
+  create_secrets_kms_key         = local.create_cluster && var.enable_secrets_encryption && var.secrets_kms_key_name == ""
+  grant_secrets_kms_key_iam      = local.create_cluster && var.enable_secrets_encryption && (local.create_secrets_kms_key || var.grant_secrets_kms_key_iam)
   secrets_kms_name_prefix        = trimsuffix(substr(replace(lower(var.cluster_name), "_", "-"), 0, 50), "-")
   secrets_kms_key_ring_name      = "${local.secrets_kms_name_prefix}-secrets-kr"
   secrets_kms_crypto_key_name    = "${local.secrets_kms_name_prefix}-secrets-key"
-  effective_secrets_kms_key_name = var.enable_secrets_encryption ? (var.secrets_kms_key_name != "" ? var.secrets_kms_key_name : google_kms_crypto_key.secrets[0].id) : ""
+  effective_secrets_kms_key_name = var.enable_secrets_encryption ? (var.secrets_kms_key_name != "" ? var.secrets_kms_key_name : try(google_kms_crypto_key.secrets[0].id, "")) : ""
   provided_secrets_kms_location  = try(split("/", var.secrets_kms_key_name)[3], "")
 }
 

--- a/modules/gcp_byoc_i/gke/kms.tf
+++ b/modules/gcp_byoc_i/gke/kms.tf
@@ -1,0 +1,60 @@
+locals {
+  create_secrets_kms_key         = var.enable_secrets_encryption && var.secrets_kms_key_name == ""
+  grant_secrets_kms_key_iam      = var.enable_secrets_encryption && (local.create_secrets_kms_key || var.grant_secrets_kms_key_iam)
+  secrets_kms_name_prefix        = trimsuffix(substr(replace(lower(var.cluster_name), "_", "-"), 0, 50), "-")
+  secrets_kms_key_ring_name      = "${local.secrets_kms_name_prefix}-secrets-kr"
+  secrets_kms_crypto_key_name    = "${local.secrets_kms_name_prefix}-secrets-key"
+  effective_secrets_kms_key_name = var.enable_secrets_encryption ? (var.secrets_kms_key_name != "" ? var.secrets_kms_key_name : google_kms_crypto_key.secrets[0].id) : ""
+  provided_secrets_kms_location  = try(split("/", var.secrets_kms_key_name)[3], "")
+}
+
+data "google_project" "this" {
+  count = local.grant_secrets_kms_key_iam ? 1 : 0
+
+  project_id = var.gcp_project_id
+}
+
+resource "google_kms_key_ring" "secrets" {
+  count = local.create_secrets_kms_key ? 1 : 0
+
+  project  = var.gcp_project_id
+  name     = local.secrets_kms_key_ring_name
+  location = var.gcp_region
+}
+
+resource "google_kms_crypto_key" "secrets" {
+  count = local.create_secrets_kms_key ? 1 : 0
+
+  name     = local.secrets_kms_crypto_key_name
+  key_ring = google_kms_key_ring.secrets[0].id
+}
+
+resource "google_kms_crypto_key_iam_member" "gke_secrets" {
+  count = local.grant_secrets_kms_key_iam ? 1 : 0
+
+  crypto_key_id = local.effective_secrets_kms_key_name
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:service-${data.google_project.this[0].number}@container-engine-robot.iam.gserviceaccount.com"
+
+  depends_on = [google_kms_crypto_key.secrets]
+}
+
+resource "terraform_data" "secrets_encryption_validation" {
+  count = var.enable_secrets_encryption && var.secrets_kms_key_name != "" ? 1 : 0
+
+  input = {
+    enabled  = var.enable_secrets_encryption
+    key_name = var.secrets_kms_key_name
+  }
+
+  lifecycle {
+    precondition {
+      condition = (
+        !var.enable_secrets_encryption ||
+        var.secrets_kms_key_name == "" ||
+        local.provided_secrets_kms_location == var.gcp_region
+      )
+      error_message = "The GKE Secrets encryption KMS key location must match gcp_region."
+    }
+  }
+}

--- a/modules/gcp_byoc_i/gke/locals.tf
+++ b/modules/gcp_byoc_i/gke/locals.tf
@@ -1,4 +1,22 @@
 locals {
+  create_cluster = var.gke_mode == "create"
+  cluster = (
+    local.create_cluster
+    ? google_container_cluster.this[0]
+    : data.google_container_cluster.existing[0]
+  )
+
+  existing_cluster_pod_range        = local.create_cluster ? "" : try(data.google_container_cluster.existing[0].ip_allocation_policy[0].cluster_secondary_range_name, "")
+  existing_cluster_service_range    = local.create_cluster ? "" : try(data.google_container_cluster.existing[0].ip_allocation_policy[0].services_secondary_range_name, "")
+  existing_cluster_workload_pool    = local.create_cluster ? "" : try(data.google_container_cluster.existing[0].workload_identity_config[0].workload_pool, "")
+  existing_cluster_private_nodes    = local.create_cluster ? false : try(data.google_container_cluster.existing[0].private_cluster_config[0].enable_private_nodes, false)
+  existing_cluster_encryption_state = local.create_cluster ? "" : try(data.google_container_cluster.existing[0].database_encryption[0].state, "")
+  existing_cluster_encryption_key   = local.create_cluster ? "" : try(data.google_container_cluster.existing[0].database_encryption[0].key_name, "")
+  existing_cluster_network          = local.create_cluster ? "" : trimprefix(data.google_container_cluster.existing[0].network, "https://www.googleapis.com/compute/v1/")
+  existing_cluster_subnetwork       = local.create_cluster ? "" : trimprefix(data.google_container_cluster.existing[0].subnetwork, "https://www.googleapis.com/compute/v1/")
+  selected_network                  = trimprefix(var.network_self_link, "https://www.googleapis.com/compute/v1/")
+  selected_subnetwork               = trimprefix(var.primary_subnet_self_link, "https://www.googleapis.com/compute/v1/")
+
   common_labels = merge(
     {
       vendor     = "zilliz-byoc"

--- a/modules/gcp_byoc_i/gke/main.tf
+++ b/modules/gcp_byoc_i/gke/main.tf
@@ -1,4 +1,6 @@
 resource "google_container_cluster" "this" {
+  count = local.create_cluster ? 1 : 0
+
   project                  = var.gcp_project_id
   name                     = var.cluster_name
   location                 = var.gcp_region
@@ -106,7 +108,7 @@ resource "google_container_node_pool" "this" {
   project            = var.gcp_project_id
   name               = each.key
   location           = var.gcp_region
-  cluster            = google_container_cluster.this.name
+  cluster            = local.cluster.name
   node_locations     = var.gcp_zones
   initial_node_count = max(each.value.desired_size, each.value.min_size)
   max_pods_per_node  = each.key == "core" ? 110 : 32
@@ -181,4 +183,6 @@ resource "google_container_node_pool" "this" {
   lifecycle {
     ignore_changes = [initial_node_count]
   }
+
+  depends_on = [terraform_data.existing_cluster_validation]
 }

--- a/modules/gcp_byoc_i/gke/main.tf
+++ b/modules/gcp_byoc_i/gke/main.tf
@@ -84,6 +84,20 @@ resource "google_container_cluster" "this" {
   workload_identity_config {
     workload_pool = "${var.gcp_project_id}.svc.id.goog"
   }
+
+  dynamic "database_encryption" {
+    for_each = var.enable_secrets_encryption ? [1] : []
+
+    content {
+      state    = "ENCRYPTED"
+      key_name = local.effective_secrets_kms_key_name
+    }
+  }
+
+  depends_on = [
+    google_kms_crypto_key_iam_member.gke_secrets,
+    terraform_data.secrets_encryption_validation,
+  ]
 }
 
 resource "google_container_node_pool" "this" {

--- a/modules/gcp_byoc_i/gke/moved.tf
+++ b/modules/gcp_byoc_i/gke/moved.tf
@@ -1,0 +1,4 @@
+moved {
+  from = google_container_cluster.this
+  to   = google_container_cluster.this[0]
+}

--- a/modules/gcp_byoc_i/gke/outputs.tf
+++ b/modules/gcp_byoc_i/gke/outputs.tf
@@ -17,3 +17,7 @@ output "private_endpoint" {
 output "node_pool_names" {
   value = keys(google_container_node_pool.this)
 }
+
+output "secrets_kms_key_name" {
+  value = local.effective_secrets_kms_key_name
+}

--- a/modules/gcp_byoc_i/gke/outputs.tf
+++ b/modules/gcp_byoc_i/gke/outputs.tf
@@ -1,17 +1,17 @@
 output "cluster_name" {
-  value = google_container_cluster.this.name
+  value = local.cluster.name
 }
 
 output "cluster_id" {
-  value = google_container_cluster.this.id
+  value = local.cluster.id
 }
 
 output "cluster_location" {
-  value = google_container_cluster.this.location
+  value = local.cluster.location
 }
 
 output "private_endpoint" {
-  value = google_container_cluster.this.private_cluster_config[0].private_endpoint
+  value = try(local.cluster.private_cluster_config[0].private_endpoint, null)
 }
 
 output "node_pool_names" {

--- a/modules/gcp_byoc_i/gke/validation.tf
+++ b/modules/gcp_byoc_i/gke/validation.tf
@@ -1,0 +1,65 @@
+resource "terraform_data" "existing_cluster_validation" {
+  count = local.create_cluster ? 0 : 1
+
+  input = {
+    cluster_name = var.cluster_name
+    gke_mode     = var.gke_mode
+  }
+
+  lifecycle {
+    precondition {
+      condition     = var.cluster_name != ""
+      error_message = "cluster_name is required when gke_mode = existing."
+    }
+
+    precondition {
+      condition     = data.google_container_cluster.existing[0].networking_mode == "VPC_NATIVE"
+      error_message = "The existing GKE cluster must use VPC_NATIVE networking."
+    }
+
+    precondition {
+      condition     = local.existing_cluster_network == local.selected_network
+      error_message = "The existing GKE cluster does not use the selected VPC."
+    }
+
+    precondition {
+      condition     = local.existing_cluster_subnetwork == local.selected_subnetwork
+      error_message = "The existing GKE cluster does not use the selected primary subnet."
+    }
+
+    precondition {
+      condition     = local.existing_cluster_pod_range == var.pod_subnet_name
+      error_message = "The existing GKE cluster Pod secondary range does not match pod_subnet_name."
+    }
+
+    precondition {
+      condition     = local.existing_cluster_service_range == var.service_subnet_name
+      error_message = "The existing GKE cluster Service secondary range does not match service_subnet_name."
+    }
+
+    precondition {
+      condition     = local.existing_cluster_private_nodes
+      error_message = "The existing GKE cluster must have private nodes enabled."
+    }
+
+    precondition {
+      condition     = local.existing_cluster_workload_pool == "${var.gcp_project_id}.svc.id.goog"
+      error_message = "The existing GKE cluster must use the Service Project workload pool <gcp_project_id>.svc.id.goog."
+    }
+
+    precondition {
+      condition     = !var.enable_secrets_encryption || var.secrets_kms_key_name != ""
+      error_message = "secrets_kms_key_name is required when validating Secrets encryption on an existing GKE cluster."
+    }
+
+    precondition {
+      condition     = !var.enable_secrets_encryption || local.existing_cluster_encryption_state == "ENCRYPTED"
+      error_message = "The existing GKE cluster must have application-layer Secrets encryption enabled."
+    }
+
+    precondition {
+      condition     = !var.enable_secrets_encryption || local.existing_cluster_encryption_key == var.secrets_kms_key_name
+      error_message = "The existing GKE cluster Secrets encryption key does not match secrets_kms_key_name."
+    }
+  }
+}

--- a/modules/gcp_byoc_i/gke/variables.tf
+++ b/modules/gcp_byoc_i/gke/variables.tf
@@ -18,6 +18,17 @@ variable "cluster_name" {
   type        = string
 }
 
+variable "gke_mode" {
+  description = "GKE cluster lifecycle mode. create provisions the cluster and node pools; existing reads an existing cluster and only provisions BYOC-I node pools."
+  type        = string
+  default     = "create"
+
+  validation {
+    condition     = contains(["create", "existing"], var.gke_mode)
+    error_message = "gke_mode must be create or existing."
+  }
+}
+
 variable "network_self_link" {
   description = "VPC network self link."
   type        = string

--- a/modules/gcp_byoc_i/gke/variables.tf
+++ b/modules/gcp_byoc_i/gke/variables.tf
@@ -87,6 +87,29 @@ variable "deletion_protection" {
   default     = false
 }
 
+variable "enable_secrets_encryption" {
+  description = "Enable GKE application-layer encryption for Kubernetes Secrets stored in etcd."
+  type        = bool
+  default     = false
+}
+
+variable "secrets_kms_key_name" {
+  description = "Existing Cloud KMS key used for GKE application-layer Secrets encryption. Leave empty to let Terraform create a regional key when enable_secrets_encryption is true."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.secrets_kms_key_name == "" || can(regex("^projects/[^/]+/locations/[^/]+/keyRings/[^/]+/cryptoKeys/[^/]+$", var.secrets_kms_key_name))
+    error_message = "secrets_kms_key_name must be empty or a full Cloud KMS crypto key resource name."
+  }
+}
+
+variable "grant_secrets_kms_key_iam" {
+  description = "Whether Terraform grants the GKE service agent roles/cloudkms.cryptoKeyEncrypterDecrypter on an existing secrets_kms_key_name. Terraform-created keys are always granted."
+  type        = bool
+  default     = true
+}
+
 variable "labels" {
   description = "Labels to apply to GKE resources."
   type        = map(string)

--- a/modules/gcp_byoc_i/private-link/main.tf
+++ b/modules/gcp_byoc_i/private-link/main.tf
@@ -1,24 +1,17 @@
-data "google_compute_network" "this" {
-  name = var.vpc_name
-}
-
-data "google_compute_subnetwork" "this" {
-  name   = var.subnet_name
-  region = var.gcp_region
-}
-
 resource "google_compute_address" "psc" {
+  project      = var.gcp_project_id
   name         = "${var.prefix_name}-psc-ip"
   region       = var.gcp_region
-  subnetwork   = data.google_compute_subnetwork.this.id
+  subnetwork   = var.subnet_self_link
   address_type = "INTERNAL"
 }
 
 resource "google_compute_forwarding_rule" "byoc_endpoint" {
+  project                 = var.gcp_project_id
   name                    = "${var.prefix_name}-byoc-endpoint"
   region                  = var.gcp_region
   load_balancing_scheme   = ""
-  network                 = data.google_compute_network.this.id
+  network                 = var.vpc_self_link
   ip_address              = google_compute_address.psc.id
   allow_psc_global_access = false
   target                  = local.service_attachment_id
@@ -34,6 +27,7 @@ resource "google_compute_forwarding_rule" "byoc_endpoint" {
 resource "google_dns_managed_zone" "psc" {
   count = var.enable_private_dns && local.private_dns_domain != "" ? 1 : 0
 
+  project     = var.network_project_id
   name        = local.private_dns_zone_name
   dns_name    = local.private_dns_domain
   description = "Private DNS zone for Zilliz BYOC Private Service Connect hosts."
@@ -41,7 +35,7 @@ resource "google_dns_managed_zone" "psc" {
 
   private_visibility_config {
     networks {
-      network_url = data.google_compute_network.this.id
+      network_url = var.vpc_self_link
     }
   }
 }
@@ -49,6 +43,7 @@ resource "google_dns_managed_zone" "psc" {
 resource "google_dns_record_set" "psc" {
   for_each = var.enable_private_dns && local.private_dns_domain != "" ? toset(var.private_dns_record_names) : toset([])
 
+  project      = var.network_project_id
   name         = endswith(each.value, ".") ? each.value : "${each.value}."
   managed_zone = google_dns_managed_zone.psc[0].name
   type         = "A"

--- a/modules/gcp_byoc_i/private-link/variables.tf
+++ b/modules/gcp_byoc_i/private-link/variables.tf
@@ -8,13 +8,23 @@ variable "gcp_region" {
   type        = string
 }
 
-variable "vpc_name" {
-  description = "VPC network name."
+variable "gcp_project_id" {
+  description = "Service project where the PSC endpoint resources are created."
   type        = string
 }
 
-variable "subnet_name" {
-  description = "Subnet name where the PSC endpoint IP is allocated."
+variable "network_project_id" {
+  description = "Project that owns the VPC. Private DNS is created in this project so it can bind to the VPC in both regular and Shared VPC modes."
+  type        = string
+}
+
+variable "vpc_self_link" {
+  description = "Full VPC self link."
+  type        = string
+}
+
+variable "subnet_self_link" {
+  description = "Full primary subnet self link."
   type        = string
 }
 

--- a/modules/gcp_byoc_i/shared-vpc-iam/main.tf
+++ b/modules/gcp_byoc_i/shared-vpc-iam/main.tf
@@ -1,0 +1,28 @@
+data "google_project" "service" {
+  project_id = var.service_project_id
+}
+
+locals {
+  gke_service_agent    = "service-${data.google_project.service.number}@container-engine-robot.iam.gserviceaccount.com"
+  cloud_services_agent = "${data.google_project.service.number}@cloudservices.gserviceaccount.com"
+  network_users = toset([
+    local.gke_service_agent,
+    local.cloud_services_agent,
+  ])
+}
+
+resource "google_project_iam_member" "gke_host_service_agent" {
+  project = var.host_project_id
+  role    = "roles/container.hostServiceAgentUser"
+  member  = "serviceAccount:${local.gke_service_agent}"
+}
+
+resource "google_compute_subnetwork_iam_member" "network_user" {
+  for_each = local.network_users
+
+  project    = var.host_project_id
+  region     = var.gcp_region
+  subnetwork = var.primary_subnet_name
+  role       = "roles/compute.networkUser"
+  member     = "serviceAccount:${each.value}"
+}

--- a/modules/gcp_byoc_i/shared-vpc-iam/outputs.tf
+++ b/modules/gcp_byoc_i/shared-vpc-iam/outputs.tf
@@ -1,0 +1,7 @@
+output "gke_service_agent" {
+  value = local.gke_service_agent
+}
+
+output "cloud_services_agent" {
+  value = local.cloud_services_agent
+}

--- a/modules/gcp_byoc_i/shared-vpc-iam/variables.tf
+++ b/modules/gcp_byoc_i/shared-vpc-iam/variables.tf
@@ -1,0 +1,19 @@
+variable "service_project_id" {
+  description = "GCP service project that owns the GKE cluster."
+  type        = string
+}
+
+variable "host_project_id" {
+  description = "Shared VPC host project."
+  type        = string
+}
+
+variable "gcp_region" {
+  description = "Region of the shared primary subnet."
+  type        = string
+}
+
+variable "primary_subnet_name" {
+  description = "Shared VPC subnet used by GKE."
+  type        = string
+}

--- a/modules/gcp_byoc_i/vpc/data.tf
+++ b/modules/gcp_byoc_i/vpc/data.tf
@@ -1,0 +1,22 @@
+data "google_compute_network" "existing" {
+  count = local.create_vpc ? 0 : 1
+
+  project = var.network_project_id
+  name    = local.vpc_name
+}
+
+data "google_compute_subnetwork" "existing_primary" {
+  count = local.create_primary_subnet ? 0 : 1
+
+  project = var.network_project_id
+  name    = local.primary_subnet_name
+  region  = var.gcp_region
+}
+
+data "google_compute_subnetwork" "existing_lb" {
+  count = local.create_lb_subnet ? 0 : 1
+
+  project = var.network_project_id
+  name    = local.lb_subnet_name
+  region  = var.gcp_region
+}

--- a/modules/gcp_byoc_i/vpc/firewall.tf
+++ b/modules/gcp_byoc_i/vpc/firewall.tf
@@ -1,0 +1,38 @@
+resource "google_compute_firewall" "allow_health_check" {
+  count = var.create_firewall_rules ? 1 : 0
+
+  project       = var.network_project_id
+  name          = "${local.firewall_name_prefix}-allow-health-check"
+  network       = local.vpc.name
+  direction     = "INGRESS"
+  source_ranges = ["130.211.0.0/22", "35.191.0.0/16"]
+  target_tags   = ["zilliz-byoc"]
+
+  allow {
+    protocol = "tcp"
+    ports    = ["19530"]
+  }
+}
+
+resource "google_compute_firewall" "allow_local" {
+  count = var.create_firewall_rules ? 1 : 0
+
+  project       = var.network_project_id
+  name          = "${local.firewall_name_prefix}-allow-local"
+  network       = local.vpc.name
+  direction     = "INGRESS"
+  source_ranges = local.internal_source_ranges
+  target_tags   = ["zilliz-byoc"]
+
+  allow {
+    protocol = "tcp"
+  }
+
+  allow {
+    protocol = "udp"
+  }
+
+  allow {
+    protocol = "icmp"
+  }
+}

--- a/modules/gcp_byoc_i/vpc/locals.tf
+++ b/modules/gcp_byoc_i/vpc/locals.tf
@@ -1,16 +1,52 @@
 locals {
-  vpc_name            = var.vpc_name != "" ? var.vpc_name : "${var.prefix_name}-vpc"
-  primary_subnet_name = var.primary_subnet.name != "" ? var.primary_subnet.name : "${var.prefix_name}-primary"
-  pod_subnet_name     = var.pod_subnet.name != "" ? var.pod_subnet.name : "${var.prefix_name}-pods"
-  service_subnet_name = var.service_subnet.name != "" ? var.service_subnet.name : "${var.prefix_name}-services"
-  lb_subnet_name      = var.lb_subnet.name != "" ? var.lb_subnet.name : "${var.prefix_name}-lb"
-  router_name         = "${var.prefix_name}-router"
-  nat_name            = "${var.prefix_name}-nat"
+  create_vpc            = var.vpc_mode == "create"
+  create_primary_subnet = var.subnet_mode == "create"
+  create_lb_subnet      = var.lb_subnet_mode == "create"
 
-  primary_subnet_cidr = var.primary_subnet.cidr != "" ? var.primary_subnet.cidr : cidrsubnet(var.vpc_cidr, 4, 0)
-  service_subnet_cidr = var.service_subnet.cidr != "" ? var.service_subnet.cidr : cidrsubnet(var.vpc_cidr, 4, 2)
-  pod_subnet_cidr     = var.pod_subnet.cidr != "" ? var.pod_subnet.cidr : cidrsubnet(var.vpc_cidr, 2, 1)
-  lb_subnet_cidr      = var.lb_subnet.cidr != "" ? var.lb_subnet.cidr : cidrsubnet(var.vpc_cidr, 8, 240)
+  vpc_name             = var.vpc_name != "" ? var.vpc_name : "${var.prefix_name}-vpc"
+  primary_subnet_name  = var.primary_subnet.name != "" ? var.primary_subnet.name : "${var.prefix_name}-primary"
+  pod_subnet_name      = var.pod_subnet.name != "" ? var.pod_subnet.name : "${var.prefix_name}-pods"
+  service_subnet_name  = var.service_subnet.name != "" ? var.service_subnet.name : "${var.prefix_name}-services"
+  lb_subnet_name       = var.lb_subnet.name != "" ? var.lb_subnet.name : "${var.prefix_name}-lb"
+  router_name          = "${var.prefix_name}-router"
+  nat_name             = "${var.prefix_name}-nat"
+  firewall_name_prefix = local.create_vpc ? local.vpc_name : var.prefix_name
+
+  created_primary_subnet_cidr = var.primary_subnet.cidr != "" ? var.primary_subnet.cidr : cidrsubnet(var.vpc_cidr, 4, 0)
+  created_service_subnet_cidr = var.service_subnet.cidr != "" ? var.service_subnet.cidr : cidrsubnet(var.vpc_cidr, 4, 2)
+  created_pod_subnet_cidr     = var.pod_subnet.cidr != "" ? var.pod_subnet.cidr : cidrsubnet(var.vpc_cidr, 2, 1)
+  created_lb_subnet_cidr      = var.lb_subnet.cidr != "" ? var.lb_subnet.cidr : cidrsubnet(var.vpc_cidr, 8, 240)
+
+  vpc = local.create_vpc ? google_compute_network.this[0] : data.google_compute_network.existing[0]
+  primary_subnet = (
+    local.create_primary_subnet
+    ? google_compute_subnetwork.primary[0]
+    : data.google_compute_subnetwork.existing_primary[0]
+  )
+  lb_subnet = (
+    local.create_lb_subnet
+    ? google_compute_subnetwork.lb[0]
+    : data.google_compute_subnetwork.existing_lb[0]
+  )
+
+  existing_pod_ranges = local.create_primary_subnet ? [] : [
+    for secondary_range in data.google_compute_subnetwork.existing_primary[0].secondary_ip_range :
+    secondary_range.ip_cidr_range if secondary_range.range_name == local.pod_subnet_name
+  ]
+  existing_service_ranges = local.create_primary_subnet ? [] : [
+    for secondary_range in data.google_compute_subnetwork.existing_primary[0].secondary_ip_range :
+    secondary_range.ip_cidr_range if secondary_range.range_name == local.service_subnet_name
+  ]
+
+  primary_subnet_cidr = local.create_primary_subnet ? local.created_primary_subnet_cidr : local.primary_subnet.ip_cidr_range
+  pod_subnet_cidr     = local.create_primary_subnet ? local.created_pod_subnet_cidr : try(one(local.existing_pod_ranges), "")
+  service_subnet_cidr = local.create_primary_subnet ? local.created_service_subnet_cidr : try(one(local.existing_service_ranges), "")
+  lb_subnet_cidr      = local.create_lb_subnet ? local.created_lb_subnet_cidr : local.lb_subnet.ip_cidr_range
+  internal_source_ranges = local.create_vpc ? [var.vpc_cidr] : distinct([
+    local.primary_subnet_cidr,
+    local.pod_subnet_cidr,
+    local.service_subnet_cidr,
+  ])
 
   labels = merge(
     {

--- a/modules/gcp_byoc_i/vpc/main.tf
+++ b/modules/gcp_byoc_i/vpc/main.tf
@@ -1,4 +1,7 @@
 resource "google_compute_network" "this" {
+  count = local.create_vpc ? 1 : 0
+
+  project                                   = var.network_project_id
   name                                      = local.vpc_name
   routing_mode                              = "REGIONAL"
   auto_create_subnetworks                   = false
@@ -7,89 +10,34 @@ resource "google_compute_network" "this" {
 }
 
 resource "google_compute_subnetwork" "primary" {
+  count = local.create_primary_subnet ? 1 : 0
+
+  project                  = var.network_project_id
   name                     = local.primary_subnet_name
-  ip_cidr_range            = local.primary_subnet_cidr
+  ip_cidr_range            = local.created_primary_subnet_cidr
   region                   = var.gcp_region
-  network                  = google_compute_network.this.id
+  network                  = local.vpc.id
   private_ip_google_access = true
 
   secondary_ip_range {
     range_name    = local.pod_subnet_name
-    ip_cidr_range = local.pod_subnet_cidr
+    ip_cidr_range = local.created_pod_subnet_cidr
   }
 
   secondary_ip_range {
     range_name    = local.service_subnet_name
-    ip_cidr_range = local.service_subnet_cidr
+    ip_cidr_range = local.created_service_subnet_cidr
   }
 }
 
 resource "google_compute_subnetwork" "lb" {
+  count = local.create_lb_subnet ? 1 : 0
+
+  project       = var.network_project_id
   name          = local.lb_subnet_name
-  ip_cidr_range = local.lb_subnet_cidr
+  ip_cidr_range = local.created_lb_subnet_cidr
   region        = var.gcp_region
-  network       = google_compute_network.this.id
+  network       = local.vpc.id
   purpose       = "REGIONAL_MANAGED_PROXY"
   role          = "ACTIVE"
-}
-
-resource "google_compute_router" "this" {
-  name    = local.router_name
-  region  = var.gcp_region
-  network = google_compute_network.this.id
-}
-
-resource "google_compute_address" "nat" {
-  name         = "${local.nat_name}-ip"
-  region       = var.gcp_region
-  address_type = "EXTERNAL"
-  network_tier = "PREMIUM"
-}
-
-resource "google_compute_router_nat" "this" {
-  name   = local.nat_name
-  router = google_compute_router.this.name
-  region = var.gcp_region
-
-  source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
-  nat_ip_allocate_option             = "MANUAL_ONLY"
-  nat_ips                            = [google_compute_address.nat.self_link]
-
-  subnetwork {
-    name                    = google_compute_subnetwork.primary.id
-    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
-  }
-}
-
-resource "google_compute_firewall" "allow_health_check" {
-  name          = "${local.vpc_name}-allow-health-check"
-  network       = google_compute_network.this.name
-  direction     = "INGRESS"
-  source_ranges = ["130.211.0.0/22", "35.191.0.0/16"]
-  target_tags   = ["zilliz-byoc"]
-
-  allow {
-    protocol = "tcp"
-    ports    = ["19530"]
-  }
-}
-
-resource "google_compute_firewall" "allow_local" {
-  name          = "${local.vpc_name}-allow-local"
-  network       = google_compute_network.this.name
-  direction     = "INGRESS"
-  source_ranges = [var.vpc_cidr]
-  target_tags   = ["zilliz-byoc"]
-
-  allow {
-    protocol = "tcp"
-  }
-
-  allow {
-    protocol = "udp"
-  }
-
-  allow {
-    protocol = "icmp"
-  }
 }

--- a/modules/gcp_byoc_i/vpc/moved.tf
+++ b/modules/gcp_byoc_i/vpc/moved.tf
@@ -1,0 +1,39 @@
+moved {
+  from = google_compute_network.this
+  to   = google_compute_network.this[0]
+}
+
+moved {
+  from = google_compute_subnetwork.primary
+  to   = google_compute_subnetwork.primary[0]
+}
+
+moved {
+  from = google_compute_subnetwork.lb
+  to   = google_compute_subnetwork.lb[0]
+}
+
+moved {
+  from = google_compute_router.this
+  to   = google_compute_router.this[0]
+}
+
+moved {
+  from = google_compute_address.nat
+  to   = google_compute_address.nat[0]
+}
+
+moved {
+  from = google_compute_router_nat.this
+  to   = google_compute_router_nat.this[0]
+}
+
+moved {
+  from = google_compute_firewall.allow_health_check
+  to   = google_compute_firewall.allow_health_check[0]
+}
+
+moved {
+  from = google_compute_firewall.allow_local
+  to   = google_compute_firewall.allow_local[0]
+}

--- a/modules/gcp_byoc_i/vpc/nat.tf
+++ b/modules/gcp_byoc_i/vpc/nat.tf
@@ -1,0 +1,35 @@
+resource "google_compute_router" "this" {
+  count = var.create_cloud_nat ? 1 : 0
+
+  project = var.network_project_id
+  name    = local.router_name
+  region  = var.gcp_region
+  network = local.vpc.id
+}
+
+resource "google_compute_address" "nat" {
+  count = var.create_cloud_nat ? 1 : 0
+
+  project      = var.network_project_id
+  name         = "${local.nat_name}-ip"
+  region       = var.gcp_region
+  address_type = "EXTERNAL"
+  network_tier = "PREMIUM"
+}
+
+resource "google_compute_router_nat" "this" {
+  count = var.create_cloud_nat ? 1 : 0
+
+  project                            = var.network_project_id
+  name                               = local.nat_name
+  router                             = google_compute_router.this[0].name
+  region                             = var.gcp_region
+  source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+  nat_ip_allocate_option             = "MANUAL_ONLY"
+  nat_ips                            = [google_compute_address.nat[0].self_link]
+
+  subnetwork {
+    name                    = local.primary_subnet.id
+    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  }
+}

--- a/modules/gcp_byoc_i/vpc/outputs.tf
+++ b/modules/gcp_byoc_i/vpc/outputs.tf
@@ -1,25 +1,33 @@
+output "network_project_id" {
+  value = var.network_project_id
+}
+
+output "is_shared_vpc" {
+  value = var.network_project_id != var.gcp_project_id
+}
+
 output "vpc_name" {
-  value = google_compute_network.this.name
+  value = local.vpc.name
 }
 
 output "vpc_id" {
-  value = google_compute_network.this.id
+  value = local.vpc.id
 }
 
 output "vpc_self_link" {
-  value = google_compute_network.this.self_link
+  value = local.vpc.self_link
 }
 
 output "primary_subnet_name" {
-  value = google_compute_subnetwork.primary.name
+  value = local.primary_subnet.name
 }
 
 output "primary_subnet_id" {
-  value = google_compute_subnetwork.primary.id
+  value = local.primary_subnet.id
 }
 
 output "primary_subnet_self_link" {
-  value = google_compute_subnetwork.primary.self_link
+  value = local.primary_subnet.self_link
 }
 
 output "primary_subnet_cidr" {
@@ -47,9 +55,9 @@ output "service_subnet_name" {
 }
 
 output "lb_subnet_name" {
-  value = google_compute_subnetwork.lb.name
+  value = local.lb_subnet.name
 }
 
 output "nat_ip" {
-  value = google_compute_address.nat.address
+  value = try(google_compute_address.nat[0].address, null)
 }

--- a/modules/gcp_byoc_i/vpc/validation.tf
+++ b/modules/gcp_byoc_i/vpc/validation.tf
@@ -1,0 +1,59 @@
+resource "terraform_data" "validation" {
+  input = {
+    vpc_mode       = var.vpc_mode
+    subnet_mode    = var.subnet_mode
+    lb_subnet_mode = var.lb_subnet_mode
+  }
+
+  lifecycle {
+    precondition {
+      condition     = var.network_project_id == var.gcp_project_id || var.vpc_mode == "existing"
+      error_message = "Shared VPC mode requires vpc_mode = existing; the Shared VPC must already exist in the host project."
+    }
+
+    precondition {
+      condition     = var.vpc_mode == "existing" || (var.subnet_mode == "create" && var.lb_subnet_mode == "create")
+      error_message = "A newly created VPC requires Terraform-created primary and LB subnets."
+    }
+
+    precondition {
+      condition     = var.vpc_mode == "create" || var.vpc_name != ""
+      error_message = "vpc_name is required when vpc_mode = existing."
+    }
+
+    precondition {
+      condition     = var.subnet_mode == "create" || var.primary_subnet.name != ""
+      error_message = "primary_subnet.name is required when subnet_mode = existing."
+    }
+
+    precondition {
+      condition     = var.subnet_mode == "create" || (var.pod_subnet.name != "" && var.service_subnet.name != "")
+      error_message = "pod_subnet.name and service_subnet.name must identify existing secondary ranges when subnet_mode = existing."
+    }
+
+    precondition {
+      condition     = var.subnet_mode == "create" || var.pod_subnet.name != var.service_subnet.name
+      error_message = "pod_subnet.name and service_subnet.name must be different secondary ranges."
+    }
+
+    precondition {
+      condition     = var.subnet_mode == "create" || (length(local.existing_pod_ranges) == 1 && length(local.existing_service_ranges) == 1)
+      error_message = "The existing primary subnet must contain exactly one matching Pod and Service secondary range."
+    }
+
+    precondition {
+      condition     = var.subnet_mode == "create" || local.primary_subnet.network == local.vpc.self_link
+      error_message = "The existing primary subnet does not belong to the selected VPC."
+    }
+
+    precondition {
+      condition     = var.lb_subnet_mode == "create" || var.lb_subnet.name != ""
+      error_message = "lb_subnet.name is required when lb_subnet_mode = existing."
+    }
+
+    precondition {
+      condition     = var.lb_subnet_mode == "create" || local.lb_subnet.network == local.vpc.self_link
+      error_message = "The existing LB subnet must belong to the selected VPC."
+    }
+  }
+}

--- a/modules/gcp_byoc_i/vpc/variables.tf
+++ b/modules/gcp_byoc_i/vpc/variables.tf
@@ -8,6 +8,49 @@ variable "gcp_region" {
   type        = string
 }
 
+variable "gcp_project_id" {
+  description = "GCP project that owns the BYOC-I service resources."
+  type        = string
+}
+
+variable "network_project_id" {
+  description = "Project that owns the VPC and subnets. Use the service project ID for a regular VPC, or the host project ID for Shared VPC."
+  type        = string
+}
+
+variable "vpc_mode" {
+  description = "Whether Terraform creates the VPC or uses an existing VPC."
+  type        = string
+  default     = "create"
+
+  validation {
+    condition     = contains(["create", "existing"], var.vpc_mode)
+    error_message = "vpc_mode must be create or existing."
+  }
+}
+
+variable "subnet_mode" {
+  description = "Whether Terraform creates the primary GKE subnet or uses an existing subnet."
+  type        = string
+  default     = "create"
+
+  validation {
+    condition     = contains(["create", "existing"], var.subnet_mode)
+    error_message = "subnet_mode must be create or existing."
+  }
+}
+
+variable "lb_subnet_mode" {
+  description = "Whether Terraform creates the regional managed proxy subnet or uses an existing subnet."
+  type        = string
+  default     = "create"
+
+  validation {
+    condition     = contains(["create", "existing"], var.lb_subnet_mode)
+    error_message = "lb_subnet_mode must be create or existing."
+  }
+}
+
 variable "vpc_name" {
   description = "VPC network name. Defaults to <prefix_name>-vpc."
   type        = string
@@ -60,4 +103,16 @@ variable "labels" {
   description = "Labels to apply to supported GCP resources."
   type        = map(string)
   default     = {}
+}
+
+variable "create_cloud_nat" {
+  description = "Whether Terraform creates a dedicated Cloud Router, external IP, and Cloud NAT for the primary subnet. Disable when existing networking already provides egress."
+  type        = bool
+  default     = true
+}
+
+variable "create_firewall_rules" {
+  description = "Whether Terraform creates the BYOC-I health-check and internal firewall rules in the network project."
+  type        = bool
+  default     = true
 }


### PR DESCRIPTION
## Summary

### Existing and Shared VPC networking

- support creating or reusing an existing VPC
- support creating or reusing primary and proxy-only subnets
- support regular VPC and Shared VPC host/service project layouts
- add scoped Shared VPC service-agent IAM bindings
- provide independent switches for Cloud NAT, firewall rules, and Shared VPC IAM management
- preserve existing VPCs and subnets during `terraform destroy`

### GKE Secrets encryption

- support GKE application-layer Secrets encryption with Cloud KMS
- create a regional KMS key automatically or use an existing key
- optionally manage the GKE service agent's key-level IAM binding
- validate that an existing KMS key is in the GKE region

### Existing GKE clusters

- add `gke_mode = "existing"` to reuse a customer-managed regional GKE cluster
- create dedicated BYOC-I node pools in the existing cluster; reusing existing node pools is not supported
- validate VPC-native networking, VPC, subnet, Pod and Service secondary ranges, private nodes, and Workload Identity
- validate the configured Secrets encryption key when encryption validation is enabled
- preserve the existing cluster during `terraform destroy` while removing Terraform-managed BYOC-I node pools
- migrate the existing Terraform cluster state address after introducing conditional cluster creation

### Documentation

- document network and GKE modes, required IAM permissions, configuration examples, and destroy behavior

## Validation

- `terraform validate`
- `git diff --check`
- `terraform plan -refresh=false` for the default create-network mode
- `terraform plan -refresh=false` for an existing VPC with new subnets
- validation failure for an existing subnet without the required secondary ranges
- Shared VPC IAM module plan
