### PR TITLE
Add kite pool storage identity bindings

### DIFF
--- a/examples/gcp-project-byoc-I/locals.tf
+++ b/examples/gcp-project-byoc-I/locals.tf
@@ -57,7 +57,7 @@ locals {
     "cloud-tunnel.${local.gcp_private_service_domain}.",
     "cloud-open-api.${local.gcp_private_service_domain}.",
   ]
-  agent_image_url   = data.zillizcloud_byoc_i_project_settings.this.op_config.agent_image_url
+  agent_image_url = data.zillizcloud_byoc_i_project_settings.this.op_config.agent_image_url
   agent_image_tag = (
     can(regex("/", local.agent_image_url)) && can(regex(":", local.agent_image_url))
     ? element(split(":", local.agent_image_url), length(split(":", local.agent_image_url)) - 1)
@@ -118,6 +118,10 @@ locals {
     {
       namespace = "index-pool"
       name      = "milvus-bucket"
+    },
+    {
+      namespace = "vectorlake-kite-pool"
+      name      = "kite-index-pool-sa"
     },
     {
       namespace = "milvus-tool"

--- a/modules/azure/byoc_i/default-aks/federations.tf
+++ b/modules/azure/byoc_i/default-aks/federations.tf
@@ -39,6 +39,19 @@ resource "azurerm_federated_identity_credential" "aks_storage_loki_federation" {
   ]
 }
 
+resource "azurerm_federated_identity_credential" "aks_storage_kite_index_pool_federation" {
+  name                = "kite-index-pool-aks-federation"
+  resource_group_name = var.resource_group_name
+  parent_id           = var.storage_identity_id
+  audience            = ["api://AzureADTokenExchange"]
+  issuer              = azurerm_kubernetes_cluster.main.oidc_issuer_url
+  subject             = "system:serviceaccount:vectorlake-kite-pool:kite-index-pool-sa"
+
+  depends_on = [
+    azurerm_kubernetes_cluster.main
+  ]
+}
+
 # AKS Federation credentials for workload identity
 # This allows Kubernetes service accounts to authenticate using the maintenance identity
 resource "azurerm_federated_identity_credential" "aks_maintenance_federation" {
@@ -55,4 +68,3 @@ resource "azurerm_federated_identity_credential" "aks_maintenance_federation" {
     azurerm_user_assigned_identity.maintenance
   ]
 }
-


### PR DESCRIPTION
## Summary
- Add GCP Workload Identity binding for vectorlake-kite-pool/kite-index-pool-sa to the BYOC-I storage service account default list.
- Add Azure federated identity credential for vectorlake-kite-pool/kite-index-pool-sa so AKS BYOC-I matches the same storage access coverage.

## Why
This prevents newly created BYOC environments from missing storage permissions for the kite index pool pod on GCP and Azure.

## Notes
- GCP change is in examples/gcp-project-byoc-I/locals.tf.
- Azure change is in modules/azure/byoc_i/default-aks/federations.tf.