### PR TITLE
fix(gcp-byoc-i): use stable Shared VPC IAM keys

### DIFF
--- a/modules/gcp_byoc_i/shared-vpc-iam/main.tf
+++ b/modules/gcp_byoc_i/shared-vpc-iam/main.tf
@@ -5,10 +5,10 @@ data "google_project" "service" {
 locals {
   gke_service_agent    = "service-${data.google_project.service.number}@container-engine-robot.iam.gserviceaccount.com"
   cloud_services_agent = "${data.google_project.service.number}@cloudservices.gserviceaccount.com"
-  network_users = toset([
-    local.gke_service_agent,
-    local.cloud_services_agent,
-  ])
+  network_users = {
+    gke_service_agent    = local.gke_service_agent
+    cloud_services_agent = local.cloud_services_agent
+  }
 }
 
 resource "google_project_iam_member" "gke_host_service_agent" {


### PR DESCRIPTION
## Summary

- replace the computed Shared VPC network-user set with a map using static keys
- keep the GKE and Cloud Services service-agent addresses as map values
- allow Terraform to determine `google_compute_subnetwork_iam_member` instance addresses during planning even when the service project number is unknown until apply

## Problem

The Shared VPC IAM module used service-agent email addresses as `for_each` set elements. Because the module depends on resources created during apply, the service project number can be unknown during planning, causing:

```text
Error: Invalid for_each argument
The "for_each" set includes values derived from resource attributes that cannot be determined until apply.
```

## Validation

- `terraform validate`
- `git diff --check`
- `terraform plan` progressed past the original `Invalid for_each argument` error; the local test then stopped because no `ZILLIZCLOUD_API_KEY` was configured
