### PR TITLE
fix(aws-byoc-i): use AMI root device for node disks

### DIFF
--- a/modules/aws_byoc_i/eks/data_ami.tf
+++ b/modules/aws_byoc_i/eks/data_ami.tf
@@ -1,0 +1,11 @@
+data "aws_ami" "node_group" {
+  for_each = {
+    for name, node_group in var.k8s_node_groups : name => node_group
+    if node_group.ami_id != null
+  }
+
+  filter {
+    name   = "image-id"
+    values = [each.value.ami_id]
+  }
+}

--- a/modules/aws_byoc_i/eks/eks_nodegroup.tf
+++ b/modules/aws_byoc_i/eks/eks_nodegroup.tf
@@ -53,7 +53,7 @@ resource "aws_launch_template" "core" {
   }
 
   block_device_mappings {
-    device_name = "/dev/xvda"
+    device_name = local.node_group_root_device_names.core
     ebs {
       delete_on_termination = "true"
       encrypted             = var.enable_ebs_kms ? "true" : "false"
@@ -115,16 +115,14 @@ resource "aws_launch_template" "init" {
     http_tokens                 = "required"
   }
 
-  dynamic "block_device_mappings" {
-    for_each = var.enable_ebs_kms ? [1] : []
-    content {
-      device_name = "/dev/xvda"
-      ebs {
-        encrypted   = "true"
-        kms_key_id  = var.ebs_kms_key_arn
-        volume_size = var.ebs_volume_size
-        volume_type = var.ebs_volume_type
-      }
+  block_device_mappings {
+    device_name = local.node_group_root_device_names.core
+    ebs {
+      delete_on_termination = "true"
+      encrypted             = var.enable_ebs_kms ? "true" : "false"
+      kms_key_id            = var.enable_ebs_kms ? var.ebs_kms_key_arn : null
+      volume_size           = var.ebs_volume_size
+      volume_type           = var.ebs_volume_type
     }
   }
 
@@ -194,7 +192,7 @@ USERDATA
   }
 
   block_device_mappings {
-    device_name = "/dev/xvda"
+    device_name = local.node_group_root_device_names.fundamental
     ebs {
       delete_on_termination = "true"
       encrypted             = var.enable_ebs_kms ? "true" : "false"
@@ -283,7 +281,7 @@ USERDATA
   }
 
   block_device_mappings {
-    device_name = "/dev/xvda"
+    device_name = local.node_group_root_device_names.search
 
     ebs {
       delete_on_termination = "true"

--- a/modules/aws_byoc_i/eks/locals.tf
+++ b/modules/aws_byoc_i/eks/locals.tf
@@ -6,6 +6,11 @@ locals {
   eks_control_plane_subnet_ids = coalescelist(var.eks_control_plane_subnet_ids, var.subnet_ids)
   config                       = yamldecode(file("${path.module}/../../conf.yaml"))
   k8s_node_groups              = var.k8s_node_groups
+  node_group_root_device_names = {
+    for name, node_group in var.k8s_node_groups : name => (
+      node_group.ami_id != null ? data.aws_ami.node_group[name].root_device_name : "/dev/xvda"
+    )
+  }
   # Dataplane ID for resource naming
   dataplane_id            = var.dataplane_id
   node_security_group_ids = var.node_security_group_ids


### PR DESCRIPTION
## Summary
- resolve each custom node group AMI root device name through AWS metadata
- use the resolved root device in core, init, default, and diskann launch templates
- always configure the init root volume, regardless of whether EBS KMS is enabled

## Root cause
The Ubuntu FIPS AMI uses `/dev/sda1` as its root device, while the launch templates hard-coded `/dev/xvda`. EC2 therefore kept the AMI's 20 GiB root volume and attached the configured 200 GiB volume as an unused second disk.

## Validation
- `terraform fmt -check -recursive modules/aws_byoc_i/eks`
- `git diff --check`
- `terraform validate` was attempted, but provider installation did not complete in the local environment and was canceled.