### PR TITLE
feat(gcp-byoc-i): support existing GCS buckets

### DIFF
--- a/examples/gcp-project-byoc-I/README.md
+++ b/examples/gcp-project-byoc-I/README.md
@@ -68,6 +68,21 @@ The existing cluster must be regional in the BYOC-I region, VPC-native, use the 
 
 In `existing` mode Terraform does not modify or own the cluster. `terraform destroy` preserves it and removes only the BYOC-I node pools and other resources created by this configuration. Reusing existing node pools is not supported.
 
+## GCS Bucket Modes
+
+`bucket_mode = "create"` is the default and creates a dedicated GCS bucket managed by this Terraform configuration.
+
+To reuse a customer-managed bucket without modifying or owning its lifecycle:
+
+```hcl
+bucket_mode          = "existing"
+customer_bucket_name = "customer-existing-bucket"
+```
+
+The bucket must already exist and be accessible to the Terraform runner. In `existing` mode, Terraform reads the bucket and still configures the BYOC-I storage IAM permissions against it, but does not change bucket settings, labels, encryption, or lifecycle. `enable_gcs_kms` must remain `false`; configure encryption on the existing bucket outside this example.
+
+Do not switch a bucket already managed in this state directly from `create` to `existing`, because Terraform would plan to destroy the managed resource. Remove it from state first with `terraform state rm module.gcs.google_storage_bucket.this[0]`, then change the mode.
+
 ### Create a Dedicated VPC and Subnets
 
 This is the default and is backward compatible:
@@ -265,7 +280,7 @@ Before destroying this example, edit `main.tf` and temporarily change the `zilli
 If you want to keep the GCS bucket and only destroy the other dataplane resources, first remove the bucket resource from this Terraform state:
 
 ```bash
-terraform state rm module.gcs.google_storage_bucket.this
+terraform state rm 'module.gcs.google_storage_bucket.this[0]'
 ```
 
 Then run destroy:
@@ -287,7 +302,7 @@ If you want `terraform destroy` to delete the GCS bucket and all objects in it, 
 ```bash
 ZILLIZCLOUD_API_KEY=<YourZillizApiKey> \
 terraform apply \
-  -target=module.gcs.google_storage_bucket.this \
+  -target='module.gcs.google_storage_bucket.this[0]' \
   -var="dataplane_id=<YourZillizDataPlaneId>" \
   -var="project_id=<YourZillizProjectId>" \
   -var="gcp_project_id=<YourGcpProjectId>" \

--- a/examples/gcp-project-byoc-I/main.tf
+++ b/examples/gcp-project-byoc-I/main.tf
@@ -16,11 +16,11 @@ module "vpc" {
   lb_subnet      = var.lb_subnet
   labels         = local.common_labels
 
-  gcp_project_id       = var.gcp_project_id
-  network_project_id   = local.network_project_id
-  vpc_mode             = var.vpc_mode
-  subnet_mode          = var.subnet_mode
-  lb_subnet_mode       = var.lb_subnet_mode
+  gcp_project_id        = var.gcp_project_id
+  network_project_id    = local.network_project_id
+  vpc_mode              = var.vpc_mode
+  subnet_mode           = var.subnet_mode
+  lb_subnet_mode        = var.lb_subnet_mode
   create_cloud_nat      = var.create_cloud_nat
   create_firewall_rules = var.create_firewall_rules
 
@@ -30,6 +30,7 @@ module "vpc" {
 module "gcs" {
   source = "../../modules/gcp_byoc_i/gcs"
 
+  bucket_mode           = var.bucket_mode
   bucket_name           = local.bucket_name
   gcp_project_id        = var.gcp_project_id
   gcp_region            = local.gcp_region
@@ -39,28 +40,28 @@ module "gcs" {
   gcs_kms_key_name      = var.gcs_kms_key_name
   grant_gcs_kms_key_iam = var.grant_gcs_kms_key_iam
 
-  depends_on = [google_project_service.required]
+  depends_on = [google_project_service.required, terraform_data.bucket_input_validation]
 }
 
 module "iam" {
   source = "../../modules/gcp_byoc_i/iam"
 
-  gcp_project_id                    = var.gcp_project_id
-  prefix_name                       = local.prefix_name
-  gke_location                      = local.gcp_region
-  gke_cluster_name                  = local.gke_cluster_name
-  storage_bucket_name               = module.gcs.bucket_id
-  gke_node_service_account_name     = var.customer_gke_node_service_account_name
-  management_service_account_name   = var.customer_management_service_account_name
-  storage_service_account_name      = var.customer_storage_service_account_name
-  booter_service_account_name       = var.customer_booter_service_account_name
-  storage_workload_identity_ksas    = local.storage_workload_identity_ksas
-  enable_direct_mig_resize          = var.enable_direct_mig_resize
-  booter_instance_name              = local.booter_vm_name
-  booter_zone                       = local.gcp_zones[0]
-  enable_resource_manager_tags      = var.enable_resource_manager_tags
-  vendor_tag_key_id                 = local.vendor_tag_key_id
-  vendor_tag_value_id               = local.vendor_tag_value_id
+  gcp_project_id                  = var.gcp_project_id
+  prefix_name                     = local.prefix_name
+  gke_location                    = local.gcp_region
+  gke_cluster_name                = local.gke_cluster_name
+  storage_bucket_name             = module.gcs.bucket_id
+  gke_node_service_account_name   = var.customer_gke_node_service_account_name
+  management_service_account_name = var.customer_management_service_account_name
+  storage_service_account_name    = var.customer_storage_service_account_name
+  booter_service_account_name     = var.customer_booter_service_account_name
+  storage_workload_identity_ksas  = local.storage_workload_identity_ksas
+  enable_direct_mig_resize        = var.enable_direct_mig_resize
+  booter_instance_name            = local.booter_vm_name
+  booter_zone                     = local.gcp_zones[0]
+  enable_resource_manager_tags    = var.enable_resource_manager_tags
+  vendor_tag_key_id               = local.vendor_tag_key_id
+  vendor_tag_value_id             = local.vendor_tag_value_id
 
   depends_on = [google_project_service.required, terraform_data.vendor_tag_input_validation]
 }
@@ -68,23 +69,23 @@ module "iam" {
 module "gke" {
   source = "../../modules/gcp_byoc_i/gke"
 
-  gke_mode                 = var.gke_mode
-  gcp_project_id           = var.gcp_project_id
-  gcp_region               = local.gcp_region
-  gcp_zones                = local.gcp_zones
-  cluster_name             = local.gke_cluster_name
-  network_self_link        = module.vpc.vpc_self_link
-  primary_subnet_self_link = module.vpc.primary_subnet_self_link
-  pod_subnet_name          = module.vpc.pod_subnet_name
-  service_subnet_name      = module.vpc.service_subnet_name
-  gke_node_sa_email        = module.iam.gke_node_sa_email
-  k8s_node_groups          = local.k8s_node_groups
-  kubernetes_version       = var.kubernetes_version
-  master_ipv4_cidr_block   = var.master_ipv4_cidr_block
+  gke_mode                  = var.gke_mode
+  gcp_project_id            = var.gcp_project_id
+  gcp_region                = local.gcp_region
+  gcp_zones                 = local.gcp_zones
+  cluster_name              = local.gke_cluster_name
+  network_self_link         = module.vpc.vpc_self_link
+  primary_subnet_self_link  = module.vpc.primary_subnet_self_link
+  pod_subnet_name           = module.vpc.pod_subnet_name
+  service_subnet_name       = module.vpc.service_subnet_name
+  gke_node_sa_email         = module.iam.gke_node_sa_email
+  k8s_node_groups           = local.k8s_node_groups
+  kubernetes_version        = var.kubernetes_version
+  master_ipv4_cidr_block    = var.master_ipv4_cidr_block
   enable_secrets_encryption = var.enable_gke_secrets_encryption
   secrets_kms_key_name      = var.gke_secrets_kms_key_name
   grant_secrets_kms_key_iam = var.grant_gke_secrets_kms_key_iam
-  labels                   = local.common_labels
+  labels                    = local.common_labels
   master_authorized_networks = [
     {
       cidr_block   = module.vpc.primary_subnet_cidr
@@ -111,11 +112,11 @@ module "private_link" {
   count  = local.enable_private_link ? 1 : 0
   source = "../../modules/gcp_byoc_i/private-link"
 
-  prefix_name           = local.prefix_name
-  gcp_region            = local.gcp_region
-  service_attachment_id = local.gcp_psc_service_attachment_id
-  enable_private_dns    = var.enable_private_dns
-  private_dns_domain    = local.psc_private_dns_domain
+  prefix_name              = local.prefix_name
+  gcp_region               = local.gcp_region
+  service_attachment_id    = local.gcp_psc_service_attachment_id
+  enable_private_dns       = var.enable_private_dns
+  private_dns_domain       = local.psc_private_dns_domain
   private_dns_record_names = local.psc_private_dns_record_names
 
   gcp_project_id     = var.gcp_project_id
@@ -130,22 +131,22 @@ module "booter_vm" {
   count  = data.zillizcloud_byoc_i_project_settings.this.agent_bootstrap_required ? 1 : 0
   source = "../../modules/gcp_byoc_i/booter-vm"
 
-  prefix_name                  = local.prefix_name
-  instance_name                = local.booter_vm_name
-  gcp_project_id               = var.gcp_project_id
-  gcp_region                   = local.gcp_region
-  gcp_zone                     = local.gcp_zones[0]
-  subnet_self_link             = module.vpc.primary_subnet_self_link
-  booter_service_account_email = module.iam.booter_sa_email
-  booter_image                 = local.booter_image
-  machine_type                 = var.booter_machine_type
+  prefix_name                     = local.prefix_name
+  instance_name                   = local.booter_vm_name
+  gcp_project_id                  = var.gcp_project_id
+  gcp_region                      = local.gcp_region
+  gcp_zone                        = local.gcp_zones[0]
+  subnet_self_link                = module.vpc.primary_subnet_self_link
+  booter_service_account_email    = module.iam.booter_sa_email
+  booter_image                    = local.booter_image
+  machine_type                    = var.booter_machine_type
   failure_self_delete_ttl_seconds = var.booter_failure_self_delete_ttl_seconds
   print_serial_logs_on_apply      = var.booter_print_serial_logs_on_apply
-  gke_cluster_name             = module.gke.cluster_name
-  dataplane_id                 = local.data_plane_id
-  agent_config                 = local.agent_config
-  labels                       = local.common_labels
-  resource_manager_tags        = local.vendor_resource_manager_tags
+  gke_cluster_name                = module.gke.cluster_name
+  dataplane_id                    = local.data_plane_id
+  agent_config                    = local.agent_config
+  labels                          = local.common_labels
+  resource_manager_tags           = local.vendor_resource_manager_tags
 
   depends_on = [google_project_service.required, terraform_data.vendor_tag_input_validation, module.iam, module.gke, module.private_link]
 }

--- a/examples/gcp-project-byoc-I/terraform.sample.tfvars
+++ b/examples/gcp-project-byoc-I/terraform.sample.tfvars
@@ -51,6 +51,9 @@ gcp_project_id = "customer-gcp-project"
 # gke_mode = "create"
 # Required when gke_mode = "existing".
 # customer_gke_cluster_name = "zilliz-byoc-gke"
+# Set to existing to reuse a customer-managed GCS bucket without managing its lifecycle.
+# bucket_mode = "create"
+# Required when bucket_mode = "existing".
 # customer_bucket_name = "zilliz-byoc-gcp-bucket"
 # bucket_force_destroy = true
 # Enable GCS bucket default encryption with a customer-managed Cloud KMS key. When gcs_kms_key_name is empty, Terraform creates a key ring and crypto key.

--- a/examples/gcp-project-byoc-I/validation.tf
+++ b/examples/gcp-project-byoc-I/validation.tf
@@ -11,3 +11,17 @@ resource "terraform_data" "gke_input_validation" {
     }
   }
 }
+
+resource "terraform_data" "bucket_input_validation" {
+  lifecycle {
+    precondition {
+      condition     = var.bucket_mode != "existing" || var.customer_bucket_name != ""
+      error_message = "customer_bucket_name is required when bucket_mode = existing."
+    }
+
+    precondition {
+      condition     = var.bucket_mode != "existing" || !var.enable_gcs_kms
+      error_message = "enable_gcs_kms must be false when bucket_mode = existing because Terraform does not modify an existing bucket."
+    }
+  }
+}

--- a/examples/gcp-project-byoc-I/variables.tf
+++ b/examples/gcp-project-byoc-I/variables.tf
@@ -121,9 +121,20 @@ variable "gke_mode" {
 }
 
 variable "customer_bucket_name" {
-  description = "Optional customer GCS bucket name."
+  description = "Optional customer GCS bucket name. Required when bucket_mode is existing."
   type        = string
   default     = ""
+}
+
+variable "bucket_mode" {
+  description = "GCS bucket lifecycle mode. create provisions and manages the bucket; existing only reads an existing bucket."
+  type        = string
+  default     = "create"
+
+  validation {
+    condition     = contains(["create", "existing"], var.bucket_mode)
+    error_message = "bucket_mode must be create or existing."
+  }
 }
 
 variable "customer_gke_node_service_account_name" {

--- a/modules/gcp_byoc_i/gcs/main.tf
+++ b/modules/gcp_byoc_i/gcs/main.tf
@@ -1,10 +1,21 @@
 locals {
-  create_gcs_kms_key         = var.enable_gcs_kms && var.gcs_kms_key_name == ""
-  grant_gcs_kms_key_iam      = var.enable_gcs_kms && (local.create_gcs_kms_key || var.grant_gcs_kms_key_iam)
+  create_gcs_kms_key         = var.bucket_mode == "create" && var.enable_gcs_kms && var.gcs_kms_key_name == ""
+  grant_gcs_kms_key_iam      = var.bucket_mode == "create" && var.enable_gcs_kms && (local.create_gcs_kms_key || var.grant_gcs_kms_key_iam)
   auto_gcs_kms_name_prefix   = trimsuffix(substr(replace(replace(lower(var.bucket_name), ".", "-"), "_", "-"), 0, 50), "-")
   gcs_kms_key_ring_name      = "${local.auto_gcs_kms_name_prefix}-kr"
   gcs_kms_crypto_key_name    = "${local.auto_gcs_kms_name_prefix}-key"
   effective_gcs_kms_key_name = var.enable_gcs_kms ? (var.gcs_kms_key_name != "" ? var.gcs_kms_key_name : google_kms_crypto_key.gcs[0].id) : ""
+}
+
+data "google_storage_bucket" "this" {
+  count = var.bucket_mode == "existing" ? 1 : 0
+
+  name = var.bucket_name
+}
+
+moved {
+  from = google_storage_bucket.this
+  to   = google_storage_bucket.this[0]
 }
 
 data "google_project" "this" {
@@ -39,6 +50,8 @@ resource "google_kms_crypto_key_iam_member" "gcs_cmek" {
 }
 
 resource "google_storage_bucket" "this" {
+  count = var.bucket_mode == "create" ? 1 : 0
+
   name                        = var.bucket_name
   location                    = var.gcp_region
   force_destroy               = var.force_destroy

--- a/modules/gcp_byoc_i/gcs/outputs.tf
+++ b/modules/gcp_byoc_i/gcs/outputs.tf
@@ -1,9 +1,9 @@
 output "bucket_id" {
-  value = google_storage_bucket.this.name
+  value = var.bucket_mode == "create" ? google_storage_bucket.this[0].name : data.google_storage_bucket.this[0].name
 }
 
 output "bucket_url" {
-  value = google_storage_bucket.this.url
+  value = var.bucket_mode == "create" ? google_storage_bucket.this[0].url : data.google_storage_bucket.this[0].url
 }
 
 output "kms_key_name" {

--- a/modules/gcp_byoc_i/gcs/variables.tf
+++ b/modules/gcp_byoc_i/gcs/variables.tf
@@ -3,6 +3,17 @@ variable "bucket_name" {
   type        = string
 }
 
+variable "bucket_mode" {
+  description = "GCS bucket lifecycle mode. create provisions and manages the bucket; existing only reads an existing bucket."
+  type        = string
+  default     = "create"
+
+  validation {
+    condition     = contains(["create", "existing"], var.bucket_mode)
+    error_message = "bucket_mode must be create or existing."
+  }
+}
+
 variable "gcp_region" {
   description = "GCP region."
   type        = string


### PR DESCRIPTION
## Summary

- add `bucket_mode = "create" | "existing"` to the GCP BYOC-I example and GCS module
- read customer-managed buckets without owning their lifecycle in `existing` mode
- preserve IAM integration and add validation, state migration, sample configuration, and documentation

## Validation

- `terraform fmt -check examples/gcp-project-byoc-I modules/gcp_byoc_i/gcs`
- `terraform validate` in `examples/gcp-project-byoc-I`
- `terraform validate` in `modules/gcp_byoc_i/gcs`