### PR TITLE
feat(gcp-byoc-i): support existing service accounts

### DIFF
--- a/examples/gcp-project-byoc-I/README.md
+++ b/examples/gcp-project-byoc-I/README.md
@@ -68,6 +68,59 @@ The existing cluster must be regional in the BYOC-I region, VPC-native, use the 
 
 In `existing` mode Terraform does not modify or own the cluster. `terraform destroy` preserves it and removes only the BYOC-I node pools and other resources created by this configuration. Reusing existing node pools is not supported.
 
+## Service Account and IAM Modes
+
+By default, Terraform creates four dedicated service accounts and manages their custom roles and IAM bindings:
+
+```hcl
+service_account_mode = "create"
+manage_iam           = true
+```
+
+To use customer-created service accounts while allowing Terraform to manage their permissions:
+
+```hcl
+service_account_mode = "existing"
+manage_iam           = true
+
+customer_gke_node_service_account_name   = "customer-zilliz-node"
+customer_management_service_account_name = "customer-zilliz-maintenance"
+customer_storage_service_account_name    = "customer-zilliz-storage"
+customer_booter_service_account_name     = "customer-zilliz-booter"
+```
+
+When the Terraform runner cannot manage IAM, the customer must create the accounts, custom roles, project IAM bindings, and Workload Identity bindings before apply:
+
+```hcl
+service_account_mode = "existing"
+manage_iam           = false
+
+customer_gke_node_service_account_name   = "customer-zilliz-node"
+customer_management_service_account_name = "customer-zilliz-maintenance"
+customer_storage_service_account_name    = "customer-zilliz-storage"
+customer_booter_service_account_name     = "customer-zilliz-booter"
+
+manage_shared_vpc_iam         = false
+grant_gcs_kms_key_iam         = false
+grant_gke_secrets_kms_key_iam = false
+```
+
+All four accounts must exist in `gcp_project_id` and have distinct account IDs. Terraform reads the accounts to obtain their canonical email and resource name but does not modify them when `manage_iam` is false.
+
+The customer-managed IAM configuration must provide the permissions defined in [`modules/gcp_byoc_i/iam/iam.tf`](../../modules/gcp_byoc_i/iam/iam.tf), including:
+
+- GKE node logging, monitoring, and default node service account permissions.
+- Maintenance cluster update, operation read, project metadata read, and optional managed-instance-group resize permissions.
+- Storage object/bucket access and storage/maintenance Workload Identity bindings.
+- Booter Kubernetes bootstrap, VM self-delete, and zone-operation read permissions.
+- `roles/iam.serviceAccountUser` from the maintenance service account to the node service account.
+
+The Terraform runner still needs `iam.serviceAccounts.actAs` on the existing GKE node and booter service accounts so it can attach them to node pools and the booter VM. Read access to the four service accounts is also required.
+
+When `manage_iam` is false and Resource Manager tags remain enabled, provide customer-created `vendor_tag_key_id` and `vendor_tag_value_id` values so the customer can preconfigure the booter self-delete IAM condition. Alternatively set `enable_resource_manager_tags = false` and scope the preconfigured permission to the exact booter VM resource name. Leaving tag IDs empty asks Terraform to create them and is unsuitable when the runner cannot manage tags or the IAM condition must be configured before apply.
+
+Do not switch an already-applied configuration directly from `create` to `existing`: removing managed service-account resources from configuration would plan their destruction. Remove the four service accounts and managed IAM resources from the Terraform state first, after verifying that the customer has recreated or adopted all required permissions. New configurations using customer-created accounts can select `existing` immediately.
+
 ## GCS Bucket Modes
 
 `bucket_mode = "create"` is the default and creates a dedicated GCS bucket managed by this Terraform configuration.

--- a/examples/gcp-project-byoc-I/main.tf
+++ b/examples/gcp-project-byoc-I/main.tf
@@ -46,6 +46,8 @@ module "gcs" {
 module "iam" {
   source = "../../modules/gcp_byoc_i/iam"
 
+  service_account_mode            = var.service_account_mode
+  manage_iam                      = var.manage_iam
   gcp_project_id                  = var.gcp_project_id
   prefix_name                     = local.prefix_name
   gke_location                    = local.gcp_region

--- a/examples/gcp-project-byoc-I/terraform.sample.tfvars
+++ b/examples/gcp-project-byoc-I/terraform.sample.tfvars
@@ -53,6 +53,21 @@ gcp_project_id = "customer-gcp-project"
 # gke_mode = "create"
 # Required when gke_mode = "existing".
 # customer_gke_cluster_name = "zilliz-byoc-gke"
+# Set existing to reuse four customer-managed service accounts.
+# service_account_mode = "create"
+# Set false when all custom roles and IAM bindings are preconfigured by the customer.
+# manage_iam = true
+# All four account IDs are required in existing mode.
+# customer_gke_node_service_account_name = "customer-zilliz-node"
+# customer_management_service_account_name = "customer-zilliz-maintenance"
+# customer_storage_service_account_name = "customer-zilliz-storage"
+# customer_booter_service_account_name = "customer-zilliz-booter"
+# With manage_iam = false, also use customer-managed IAM/KMS grants and pre-created tags:
+# manage_shared_vpc_iam = false
+# grant_gcs_kms_key_iam = false
+# grant_gke_secrets_kms_key_iam = false
+# vendor_tag_key_id = "tagKeys/1234567890"
+# vendor_tag_value_id = "tagValues/1234567890"
 # gke_enable_private_endpoint = true
 # gke_enable_private_nodes = true
 # gke_enable_ip_alias = true

--- a/examples/gcp-project-byoc-I/variables.tf
+++ b/examples/gcp-project-byoc-I/variables.tf
@@ -132,6 +132,23 @@ variable "customer_bucket_name" {
   default     = ""
 }
 
+variable "service_account_mode" {
+  description = "Service account lifecycle mode. create provisions the four BYOC-I service accounts; existing reads customer-managed accounts."
+  type        = string
+  default     = "create"
+
+  validation {
+    condition     = contains(["create", "existing"], var.service_account_mode)
+    error_message = "service_account_mode must be create or existing."
+  }
+}
+
+variable "manage_iam" {
+  description = "Whether Terraform creates BYOC-I custom roles and manages project/service-account IAM bindings."
+  type        = bool
+  default     = true
+}
+
 variable "bucket_mode" {
   description = "GCS bucket lifecycle mode. create provisions and manages the bucket; existing only reads an existing bucket."
   type        = string
@@ -144,25 +161,25 @@ variable "bucket_mode" {
 }
 
 variable "customer_gke_node_service_account_name" {
-  description = "Optional GKE node service account account_id."
+  description = "Optional GKE node service account account_id. Required when service_account_mode is existing."
   type        = string
   default     = ""
 }
 
 variable "customer_management_service_account_name" {
-  description = "Optional maintenance service account account_id."
+  description = "Optional maintenance service account account_id. Required when service_account_mode is existing."
   type        = string
   default     = ""
 }
 
 variable "customer_storage_service_account_name" {
-  description = "Optional storage service account account_id."
+  description = "Optional storage service account account_id. Required when service_account_mode is existing."
   type        = string
   default     = ""
 }
 
 variable "customer_booter_service_account_name" {
-  description = "Optional booter VM service account account_id."
+  description = "Optional booter VM service account account_id. Required when service_account_mode is existing."
   type        = string
   default     = ""
 }

--- a/modules/gcp_byoc_i/iam/iam.tf
+++ b/modules/gcp_byoc_i/iam/iam.tf
@@ -1,7 +1,9 @@
 resource "google_project_iam_member" "gke_node_default" {
+  count = var.manage_iam ? 1 : 0
+
   project = var.gcp_project_id
   role    = "roles/container.defaultNodeServiceAccount"
-  member  = "serviceAccount:${google_service_account.gke_node.email}"
+  member  = "serviceAccount:${local.gke_node_sa.email}"
 
   condition {
     title       = "zilliz_byoc_i_target_cluster_node_sa"
@@ -11,18 +13,24 @@ resource "google_project_iam_member" "gke_node_default" {
 }
 
 resource "google_project_iam_member" "gke_node_logging" {
+  count = var.manage_iam ? 1 : 0
+
   project = var.gcp_project_id
   role    = "roles/logging.logWriter"
-  member  = "serviceAccount:${google_service_account.gke_node.email}"
+  member  = "serviceAccount:${local.gke_node_sa.email}"
 }
 
 resource "google_project_iam_member" "gke_node_monitoring" {
+  count = var.manage_iam ? 1 : 0
+
   project = var.gcp_project_id
   role    = "roles/monitoring.metricWriter"
-  member  = "serviceAccount:${google_service_account.gke_node.email}"
+  member  = "serviceAccount:${local.gke_node_sa.email}"
 }
 
 resource "google_project_iam_custom_role" "maintenance_cluster" {
+  count = var.manage_iam ? 1 : 0
+
   project     = var.gcp_project_id
   role_id     = "zillizByocIClusterMaintenance${local.role_suffix}"
   title       = "Zilliz BYOC-I Cluster Maintenance ${var.prefix_name}"
@@ -35,9 +43,11 @@ resource "google_project_iam_custom_role" "maintenance_cluster" {
 }
 
 resource "google_project_iam_member" "maintenance_cluster" {
+  count = var.manage_iam ? 1 : 0
+
   project = var.gcp_project_id
-  role    = google_project_iam_custom_role.maintenance_cluster.id
-  member  = "serviceAccount:${google_service_account.management.email}"
+  role    = google_project_iam_custom_role.maintenance_cluster[0].id
+  member  = "serviceAccount:${local.management_sa.email}"
 
   condition {
     title       = "zilliz_byoc_i_target_cluster"
@@ -47,6 +57,8 @@ resource "google_project_iam_member" "maintenance_cluster" {
 }
 
 resource "google_project_iam_custom_role" "maintenance_operations" {
+  count = var.manage_iam ? 1 : 0
+
   project     = var.gcp_project_id
   role_id     = "zillizByocIOperationViewer${local.role_suffix}"
   title       = "Zilliz BYOC-I Operation Viewer ${var.prefix_name}"
@@ -59,9 +71,11 @@ resource "google_project_iam_custom_role" "maintenance_operations" {
 }
 
 resource "google_project_iam_member" "maintenance_operations" {
+  count = var.manage_iam ? 1 : 0
+
   project = var.gcp_project_id
-  role    = google_project_iam_custom_role.maintenance_operations.id
-  member  = "serviceAccount:${google_service_account.management.email}"
+  role    = google_project_iam_custom_role.maintenance_operations[0].id
+  member  = "serviceAccount:${local.management_sa.email}"
 
   condition {
     title       = "zilliz_byoc_i_gke_operations"
@@ -71,6 +85,8 @@ resource "google_project_iam_member" "maintenance_operations" {
 }
 
 resource "google_project_iam_custom_role" "booter_kubernetes_bootstrap" {
+  count = var.manage_iam ? 1 : 0
+
   project     = var.gcp_project_id
   role_id     = "zillizByocIK8sBootstrap${local.role_suffix}"
   title       = "Zilliz BYOC-I Kubernetes Bootstrap ${var.prefix_name}"
@@ -134,12 +150,16 @@ resource "google_project_iam_custom_role" "booter_kubernetes_bootstrap" {
 }
 
 resource "google_project_iam_member" "booter_kubernetes_bootstrap" {
+  count = var.manage_iam ? 1 : 0
+
   project = var.gcp_project_id
-  role    = google_project_iam_custom_role.booter_kubernetes_bootstrap.id
-  member  = "serviceAccount:${google_service_account.booter.email}"
+  role    = google_project_iam_custom_role.booter_kubernetes_bootstrap[0].id
+  member  = "serviceAccount:${local.booter_sa.email}"
 }
 
 resource "google_project_iam_custom_role" "maintenance_project_reader" {
+  count = var.manage_iam ? 1 : 0
+
   project     = var.gcp_project_id
   role_id     = "zillizByocIProjectReader${local.role_suffix}"
   title       = "Zilliz BYOC-I Project Reader ${var.prefix_name}"
@@ -151,19 +171,23 @@ resource "google_project_iam_custom_role" "maintenance_project_reader" {
 }
 
 resource "google_project_iam_member" "maintenance_project_reader" {
+  count = var.manage_iam ? 1 : 0
+
   project = var.gcp_project_id
-  role    = google_project_iam_custom_role.maintenance_project_reader.id
-  member  = "serviceAccount:${google_service_account.management.email}"
+  role    = google_project_iam_custom_role.maintenance_project_reader[0].id
+  member  = "serviceAccount:${local.management_sa.email}"
 }
 
 resource "google_service_account_iam_member" "management_can_use_node_sa" {
-  service_account_id = google_service_account.gke_node.name
+  count = var.manage_iam ? 1 : 0
+
+  service_account_id = local.gke_node_sa.name
   role               = "roles/iam.serviceAccountUser"
-  member             = "serviceAccount:${google_service_account.management.email}"
+  member             = "serviceAccount:${local.management_sa.email}"
 }
 
 resource "google_project_iam_custom_role" "maintenance_mig_resize" {
-  count = var.enable_direct_mig_resize ? 1 : 0
+  count = var.manage_iam && var.enable_direct_mig_resize ? 1 : 0
 
   project     = var.gcp_project_id
   role_id     = "zillizByocIMigResize${local.role_suffix}"
@@ -178,11 +202,11 @@ resource "google_project_iam_custom_role" "maintenance_mig_resize" {
 }
 
 resource "google_project_iam_member" "maintenance_mig_resize" {
-  count = var.enable_direct_mig_resize ? 1 : 0
+  count = var.manage_iam && var.enable_direct_mig_resize ? 1 : 0
 
   project = var.gcp_project_id
   role    = google_project_iam_custom_role.maintenance_mig_resize[0].id
-  member  = "serviceAccount:${google_service_account.management.email}"
+  member  = "serviceAccount:${local.management_sa.email}"
 
   condition {
     title       = "zilliz_byoc_i_gke_mig_only"
@@ -192,9 +216,11 @@ resource "google_project_iam_member" "maintenance_mig_resize" {
 }
 
 resource "google_project_iam_member" "storage_object_admin" {
+  count = var.manage_iam ? 1 : 0
+
   project = var.gcp_project_id
   role    = "roles/storage.objectAdmin"
-  member  = "serviceAccount:${google_service_account.storage.email}"
+  member  = "serviceAccount:${local.storage_sa.email}"
 
   condition {
     title       = "zilliz_byoc_i_storage_object_admin"
@@ -204,9 +230,11 @@ resource "google_project_iam_member" "storage_object_admin" {
 }
 
 resource "google_project_iam_member" "storage_bucket_viewer" {
+  count = var.manage_iam ? 1 : 0
+
   project = var.gcp_project_id
   role    = "roles/storage.bucketViewer"
-  member  = "serviceAccount:${google_service_account.storage.email}"
+  member  = "serviceAccount:${local.storage_sa.email}"
 
   condition {
     title       = "zilliz_byoc_i_storage_bucket_viewer"
@@ -216,34 +244,38 @@ resource "google_project_iam_member" "storage_bucket_viewer" {
 }
 
 resource "google_service_account_iam_member" "storage_workload_identity" {
-  for_each = {
+  for_each = var.manage_iam ? {
     for ksa in var.storage_workload_identity_ksas :
     "${ksa.namespace}/${ksa.name}" => ksa
-  }
+  } : {}
 
-  service_account_id = google_service_account.storage.name
+  service_account_id = local.storage_sa.name
   role               = "roles/iam.workloadIdentityUser"
   member             = "serviceAccount:${var.gcp_project_id}.svc.id.goog[${each.value.namespace}/${each.value.name}]"
 }
 
 resource "google_service_account_iam_member" "management_workload_identity" {
-  for_each = {
+  for_each = var.manage_iam ? {
     for ksa in var.management_workload_identity_ksas :
     "${ksa.namespace}/${ksa.name}" => ksa
-  }
+  } : {}
 
-  service_account_id = google_service_account.management.name
+  service_account_id = local.management_sa.name
   role               = "roles/iam.workloadIdentityUser"
   member             = "serviceAccount:${var.gcp_project_id}.svc.id.goog[${each.value.namespace}/${each.value.name}]"
 }
 
 resource "google_service_account_iam_member" "storage_workload_identity_cluster" {
-  service_account_id = google_service_account.storage.name
+  count = var.manage_iam ? 1 : 0
+
+  service_account_id = local.storage_sa.name
   role               = "roles/iam.workloadIdentityUser"
   member             = local.storage_cluster_workload_identity_member
 }
 
 resource "google_project_iam_custom_role" "booter_self_delete" {
+  count = var.manage_iam ? 1 : 0
+
   project = var.gcp_project_id
   role_id = "zillizByocIBooterDelete${local.role_suffix}"
   title   = "Zilliz BYOC-I Booter Self Delete ${var.prefix_name}"
@@ -281,9 +313,11 @@ resource "terraform_data" "booter_self_delete_tag_validation" {
 }
 
 resource "google_project_iam_member" "booter_self_delete" {
+  count = var.manage_iam ? 1 : 0
+
   project = var.gcp_project_id
-  role    = google_project_iam_custom_role.booter_self_delete.id
-  member  = "serviceAccount:${google_service_account.booter.email}"
+  role    = google_project_iam_custom_role.booter_self_delete[0].id
+  member  = "serviceAccount:${local.booter_sa.email}"
 
   condition {
     title       = "zilliz_byoc_i_booter_self_delete"
@@ -295,6 +329,8 @@ resource "google_project_iam_member" "booter_self_delete" {
 }
 
 resource "google_project_iam_custom_role" "booter_zone_operation_viewer" {
+  count = var.manage_iam ? 1 : 0
+
   project     = var.gcp_project_id
   role_id     = "zillizByocIBooterOpViewer${local.role_suffix}"
   title       = "Zilliz BYOC-I Booter Operation Viewer ${var.prefix_name}"
@@ -306,9 +342,11 @@ resource "google_project_iam_custom_role" "booter_zone_operation_viewer" {
 }
 
 resource "google_project_iam_member" "booter_zone_operation_viewer" {
+  count = var.manage_iam ? 1 : 0
+
   project = var.gcp_project_id
-  role    = google_project_iam_custom_role.booter_zone_operation_viewer.id
-  member  = "serviceAccount:${google_service_account.booter.email}"
+  role    = google_project_iam_custom_role.booter_zone_operation_viewer[0].id
+  member  = "serviceAccount:${local.booter_sa.email}"
 
   condition {
     title       = "zilliz_byoc_i_booter_zone_operations"

--- a/modules/gcp_byoc_i/iam/locals.tf
+++ b/modules/gcp_byoc_i/iam/locals.tf
@@ -1,11 +1,16 @@
 locals {
-  sa_prefix          = trimsuffix(substr(var.prefix_name, 0, 18), "-")
-  gke_node_sa_name   = var.gke_node_service_account_name != "" ? var.gke_node_service_account_name : "${local.sa_prefix}-node"
-  management_sa_name = var.management_service_account_name != "" ? var.management_service_account_name : "${local.sa_prefix}-maintenance"
-  storage_sa_name    = var.storage_service_account_name != "" ? var.storage_service_account_name : "${local.sa_prefix}-storage"
-  booter_sa_name     = var.booter_service_account_name != "" ? var.booter_service_account_name : "${local.sa_prefix}-booter"
-  role_suffix_raw    = replace(title(replace(var.prefix_name, "-", " ")), " ", "")
-  role_suffix        = substr(local.role_suffix_raw, 0, 20)
+  sa_prefix               = trimsuffix(substr(var.prefix_name, 0, 18), "-")
+  gke_node_sa_name        = var.gke_node_service_account_name != "" ? var.gke_node_service_account_name : "${local.sa_prefix}-node"
+  management_sa_name      = var.management_service_account_name != "" ? var.management_service_account_name : "${local.sa_prefix}-maintenance"
+  storage_sa_name         = var.storage_service_account_name != "" ? var.storage_service_account_name : "${local.sa_prefix}-storage"
+  booter_sa_name          = var.booter_service_account_name != "" ? var.booter_service_account_name : "${local.sa_prefix}-booter"
+  create_service_accounts = var.service_account_mode == "create"
+  gke_node_sa             = local.create_service_accounts ? google_service_account.gke_node[0] : data.google_service_account.gke_node[0]
+  management_sa           = local.create_service_accounts ? google_service_account.management[0] : data.google_service_account.management[0]
+  storage_sa              = local.create_service_accounts ? google_service_account.storage[0] : data.google_service_account.storage[0]
+  booter_sa               = local.create_service_accounts ? google_service_account.booter[0] : data.google_service_account.booter[0]
+  role_suffix_raw         = replace(title(replace(var.prefix_name, "-", " ")), " ", "")
+  role_suffix             = substr(local.role_suffix_raw, 0, 20)
 
   storage_cluster_workload_identity_member = "principalSet://iam.googleapis.com/projects/${data.google_project.this.number}/locations/global/workloadIdentityPools/${var.gcp_project_id}.svc.id.goog/kubernetes.cluster/https://container.googleapis.com/v1/projects/${var.gcp_project_id}/locations/${var.gke_location}/clusters/${var.gke_cluster_name}"
 

--- a/modules/gcp_byoc_i/iam/migrations.tf
+++ b/modules/gcp_byoc_i/iam/migrations.tf
@@ -1,0 +1,94 @@
+moved {
+  from = google_project_iam_member.gke_node_default
+  to   = google_project_iam_member.gke_node_default[0]
+}
+
+moved {
+  from = google_project_iam_member.gke_node_logging
+  to   = google_project_iam_member.gke_node_logging[0]
+}
+
+moved {
+  from = google_project_iam_member.gke_node_monitoring
+  to   = google_project_iam_member.gke_node_monitoring[0]
+}
+
+moved {
+  from = google_project_iam_custom_role.maintenance_cluster
+  to   = google_project_iam_custom_role.maintenance_cluster[0]
+}
+
+moved {
+  from = google_project_iam_member.maintenance_cluster
+  to   = google_project_iam_member.maintenance_cluster[0]
+}
+
+moved {
+  from = google_project_iam_custom_role.maintenance_operations
+  to   = google_project_iam_custom_role.maintenance_operations[0]
+}
+
+moved {
+  from = google_project_iam_member.maintenance_operations
+  to   = google_project_iam_member.maintenance_operations[0]
+}
+
+moved {
+  from = google_project_iam_custom_role.booter_kubernetes_bootstrap
+  to   = google_project_iam_custom_role.booter_kubernetes_bootstrap[0]
+}
+
+moved {
+  from = google_project_iam_member.booter_kubernetes_bootstrap
+  to   = google_project_iam_member.booter_kubernetes_bootstrap[0]
+}
+
+moved {
+  from = google_project_iam_custom_role.maintenance_project_reader
+  to   = google_project_iam_custom_role.maintenance_project_reader[0]
+}
+
+moved {
+  from = google_project_iam_member.maintenance_project_reader
+  to   = google_project_iam_member.maintenance_project_reader[0]
+}
+
+moved {
+  from = google_service_account_iam_member.management_can_use_node_sa
+  to   = google_service_account_iam_member.management_can_use_node_sa[0]
+}
+
+moved {
+  from = google_project_iam_member.storage_object_admin
+  to   = google_project_iam_member.storage_object_admin[0]
+}
+
+moved {
+  from = google_project_iam_member.storage_bucket_viewer
+  to   = google_project_iam_member.storage_bucket_viewer[0]
+}
+
+moved {
+  from = google_service_account_iam_member.storage_workload_identity_cluster
+  to   = google_service_account_iam_member.storage_workload_identity_cluster[0]
+}
+
+moved {
+  from = google_project_iam_custom_role.booter_self_delete
+  to   = google_project_iam_custom_role.booter_self_delete[0]
+}
+
+moved {
+  from = google_project_iam_member.booter_self_delete
+  to   = google_project_iam_member.booter_self_delete[0]
+}
+
+moved {
+  from = google_project_iam_custom_role.booter_zone_operation_viewer
+  to   = google_project_iam_custom_role.booter_zone_operation_viewer[0]
+}
+
+moved {
+  from = google_project_iam_member.booter_zone_operation_viewer
+  to   = google_project_iam_member.booter_zone_operation_viewer[0]
+}

--- a/modules/gcp_byoc_i/iam/outputs.tf
+++ b/modules/gcp_byoc_i/iam/outputs.tf
@@ -1,15 +1,15 @@
 output "gke_node_sa_email" {
-  value = google_service_account.gke_node.email
+  value = local.gke_node_sa.email
 }
 
 output "management_sa_email" {
-  value = google_service_account.management.email
+  value = local.management_sa.email
 }
 
 output "storage_sa_email" {
-  value = google_service_account.storage.email
+  value = local.storage_sa.email
 }
 
 output "booter_sa_email" {
-  value = google_service_account.booter.email
+  value = local.booter_sa.email
 }

--- a/modules/gcp_byoc_i/iam/service_accounts.tf
+++ b/modules/gcp_byoc_i/iam/service_accounts.tf
@@ -16,10 +16,27 @@ resource "terraform_data" "service_account_name_validation" {
       ])) == 4
       error_message = "GKE node, maintenance, storage, and booter service account names must be distinct. The booter VM must use a dedicated booter service account."
     }
+
+    precondition {
+      condition = var.service_account_mode != "existing" || alltrue([
+        var.gke_node_service_account_name != "",
+        var.management_service_account_name != "",
+        var.storage_service_account_name != "",
+        var.booter_service_account_name != "",
+      ])
+      error_message = "All four service account names are required when service_account_mode is existing."
+    }
+
+    precondition {
+      condition     = var.manage_iam || var.service_account_mode == "existing"
+      error_message = "manage_iam can be false only when service_account_mode is existing."
+    }
   }
 }
 
 resource "google_service_account" "gke_node" {
+  count = local.create_service_accounts ? 1 : 0
+
   project      = var.gcp_project_id
   account_id   = local.gke_node_sa_name
   display_name = "Zilliz BYOC-I GKE node service account"
@@ -28,6 +45,8 @@ resource "google_service_account" "gke_node" {
 }
 
 resource "google_service_account" "management" {
+  count = local.create_service_accounts ? 1 : 0
+
   project      = var.gcp_project_id
   account_id   = local.management_sa_name
   display_name = "Zilliz BYOC-I maintenance service account"
@@ -36,6 +55,8 @@ resource "google_service_account" "management" {
 }
 
 resource "google_service_account" "storage" {
+  count = local.create_service_accounts ? 1 : 0
+
   project      = var.gcp_project_id
   account_id   = local.storage_sa_name
   display_name = "Zilliz BYOC-I storage service account"
@@ -44,9 +65,59 @@ resource "google_service_account" "storage" {
 }
 
 resource "google_service_account" "booter" {
+  count = local.create_service_accounts ? 1 : 0
+
   project      = var.gcp_project_id
   account_id   = local.booter_sa_name
   display_name = "Zilliz BYOC-I booter service account"
 
   depends_on = [terraform_data.service_account_name_validation]
+}
+
+data "google_service_account" "gke_node" {
+  count = local.create_service_accounts ? 0 : 1
+
+  project    = var.gcp_project_id
+  account_id = local.gke_node_sa_name
+}
+
+data "google_service_account" "management" {
+  count = local.create_service_accounts ? 0 : 1
+
+  project    = var.gcp_project_id
+  account_id = local.management_sa_name
+}
+
+data "google_service_account" "storage" {
+  count = local.create_service_accounts ? 0 : 1
+
+  project    = var.gcp_project_id
+  account_id = local.storage_sa_name
+}
+
+data "google_service_account" "booter" {
+  count = local.create_service_accounts ? 0 : 1
+
+  project    = var.gcp_project_id
+  account_id = local.booter_sa_name
+}
+
+moved {
+  from = google_service_account.gke_node
+  to   = google_service_account.gke_node[0]
+}
+
+moved {
+  from = google_service_account.management
+  to   = google_service_account.management[0]
+}
+
+moved {
+  from = google_service_account.storage
+  to   = google_service_account.storage[0]
+}
+
+moved {
+  from = google_service_account.booter
+  to   = google_service_account.booter[0]
 }

--- a/modules/gcp_byoc_i/iam/variables.tf
+++ b/modules/gcp_byoc_i/iam/variables.tf
@@ -23,26 +23,43 @@ variable "storage_bucket_name" {
   type        = string
 }
 
+variable "service_account_mode" {
+  description = "Service account lifecycle mode. create provisions the four BYOC-I service accounts; existing reads customer-managed accounts."
+  type        = string
+  default     = "create"
+
+  validation {
+    condition     = contains(["create", "existing"], var.service_account_mode)
+    error_message = "service_account_mode must be create or existing."
+  }
+}
+
+variable "manage_iam" {
+  description = "Whether Terraform creates BYOC-I custom roles and manages project/service-account IAM bindings."
+  type        = bool
+  default     = true
+}
+
 variable "gke_node_service_account_name" {
-  description = "GKE node service account account_id. Defaults to <prefix_name>-node."
+  description = "GKE node service account account_id. Defaults to <prefix_name>-node in create mode and is required in existing mode."
   type        = string
   default     = ""
 }
 
 variable "management_service_account_name" {
-  description = "Maintenance service account account_id. Defaults to <prefix_name>-maintenance."
+  description = "Maintenance service account account_id. Defaults to <prefix_name>-maintenance in create mode and is required in existing mode."
   type        = string
   default     = ""
 }
 
 variable "storage_service_account_name" {
-  description = "Storage service account account_id. Defaults to <prefix_name>-storage."
+  description = "Storage service account account_id. Defaults to <prefix_name>-storage in create mode and is required in existing mode."
   type        = string
   default     = ""
 }
 
 variable "booter_service_account_name" {
-  description = "Booter VM service account account_id. Defaults to <prefix_name>-booter."
+  description = "Booter VM service account account_id. Defaults to <prefix_name>-booter in create mode and is required in existing mode."
   type        = string
   default     = ""
 }


### PR DESCRIPTION
## Summary

- add independent `service_account_mode = create | existing` and `manage_iam` controls
- read four customer-managed BYOC-I service accounts in existing mode while keeping existing outputs and downstream wiring
- skip all custom roles, project IAM, and service-account IAM bindings when `manage_iam = false`
- preserve default behavior and add moved blocks for existing Terraform state addresses
- document customer-managed IAM prerequisites, runner `actAs` requirements, tag considerations, and migration safety

## Customer-managed example

```hcl
service_account_mode = "existing"
manage_iam           = false

customer_gke_node_service_account_name   = "customer-zilliz-node"
customer_management_service_account_name = "customer-zilliz-maintenance"
customer_storage_service_account_name    = "customer-zilliz-storage"
customer_booter_service_account_name     = "customer-zilliz-booter"
```

## Validation

- `terraform fmt -check examples/gcp-project-byoc-I modules/gcp_byoc_i/iam`
- `terraform validate` in `examples/gcp-project-byoc-I`